### PR TITLE
XML Converter

### DIFF
--- a/src/xml_converter/src/reuse/encoding/entities
+++ b/src/xml_converter/src/reuse/encoding/entities
@@ -507,3 +507,7 @@ hairsp|&#8202;|&hairsp;|hair space|hairsp
 ♀|&#x2640;|&female;|female|female
 ♂|&#9794;|&male;|male|male
 ♂|&#x2642;|&male;|male|male
+/|&#47;|&sol;|solidus|/
+(|&#40;|&lpar;|left parenthesis|(
+)|&#41;|&rpar;|right parenthesis|)
+

--- a/src/xml_converter/src/xml2db/custom/articles/db/isis/json2article.py
+++ b/src/xml_converter/src/xml2db/custom/articles/db/isis/json2article.py
@@ -17,6 +17,7 @@ def return_journals_list(json):
     json_title = JSON_Journal()
     for json_item in json:
         json_title.load(json_item)
+        #print(json_title.journal_title+ '.')
         j = Journal(json_title.journal_title, json_title.journal_issn_id, json_title.journal_acron)
         j.publishers = json_title.publishers
         journal_list.insert(j, False)
@@ -32,6 +33,8 @@ def return_issues_list(json_issues, journals):
         if j != None:
             json_issue.load(json)
             issue = json_issue.return_issue(j)
+            #print(json_issue.journal_title + '.')
+            #print(issue.name + '.')
             issues_list.insert(issue, False)
     return issues_list
 
@@ -1036,7 +1039,14 @@ class AffiliationsHandler:
                     status = ''
                     if required_key in fixed:
                         status = '(automatically identified)'
-                    present.append(required_label +': ' + aff[required_key] + status)
+                    if type(aff[required_key]) == type(''):
+                        present.append(required_label +': ' + aff[required_key] + status)
+                    else:
+                        try:
+                            present.append(required_label+': ' + str(aff[required_key]) + status)
+                        except:
+                            present.append(required_label+': ' + required_key + status)
+                            print(aff[required_key])
                     
                 else:
                     missing_parts.append(required_label)

--- a/src/xml_converter/src/xml2db/custom/articles/models/journal_issue_article.py
+++ b/src/xml_converter/src/xml2db/custom/articles/models/journal_issue_article.py
@@ -65,7 +65,7 @@ class Journal:
         self.publishers = ''
 
     def generate_id(self, journal_title):
-        return id_generate( journal_title)
+        return id_generate( journal_title.strip())
  
 class JournalIssueOrder:
     def __init__(self):

--- a/src/xml_converter/src/xml2db/xml_to_db.py
+++ b/src/xml_converter/src/xml2db/xml_to_db.py
@@ -279,7 +279,10 @@ class InformationAnalyst:
         
         if not is_well_formed:
             package.report.write('XML file was not well formed. Unable to read it', True, True)
-        
+            #validation_path = package.package_path.replace('/work/', '/4check/')
+            #shutil.copyfile(xml_filename, validation_path)
+            #self.reports_to_attach.append(validation_path + '/' + os.path.basename(xml_filename))
+            self.reports_to_attach.append(xml_filename)
         return is_well_formed
         
 

--- a/src/xml_converter/src/xml_2db.py
+++ b/src/xml_converter/src/xml_2db.py
@@ -149,10 +149,10 @@ if parameters.check_parameters(sys.argv):
         
         json_titles = documents_archiver.db2json('title')
         json_boxes = documents_archiver.db2json('issue')
-                
         #
         registered_titles = return_journals_list(json_titles)
         registered_boxes = return_issues_list(json_boxes, registered_titles)
+        
         
 
         all_boxes = AllFolders(registered_boxes, JournalIssuesList(), AllIssues())


### PR DESCRIPTION
- Entities: treatment for lpar, rpar, sol, that are (, ), /.
- When XML is not well formed and/or has invalid entities, it is attached to the e-mail (report).
- Journal title had a space at the end, in title database, and articles for this journal were not loaded, because the titles were unmatched. Solution: ignore spaces before and after title.
