### PR TITLE
Dois ajustes no script export.

### DIFF
--- a/src/scielo/export/ExportSerial.bat
+++ b/src/scielo/export/ExportSerial.bat
@@ -7,6 +7,7 @@ echo   Tecle CONTROL-C para sair ou ENTER para continuar...
 
 pause > nul
 
+if not exist temp md temp
 call notepad temp\title.lst
 cls
 echo -----------------------

--- a/src/scielo/export/scripts/ExportSerial_append.bat
+++ b/src/scielo/export/scripts/ExportSerial_append.bat
@@ -1,4 +1,7 @@
 cisis\mx %1\title\title     text=%2 "proc=if v68='%2'  then else 'd*' fi" append=temp\serial\title\title now -all
-cisis\mx %1\issue\issue     text=%3 "proc=if v930='%3' then else 'd*' fi" append=temp\serial\issue\issue now -all
-cisis\mx %1\section\section text=%3 "proc=if v930='%3' then else 'd*' fi" append=temp\serial\section\section now -all
+cisis\mx %1\issue\issue     "proc=if s(mpl,v930,mpu)=s(mpl,'%2',mpu) then else 'd*' fi" append=temp\serial\issue\issue now -all
+cisis\mx %1\section\section "proc=if s(mpl,v930,mpu)=s(mpl,'%2',mpu) then else 'd*' fi" append=temp\serial\section\section now -all
 
+cisis\mx temp\serial\title\title now +control
+cisis\mx temp\serial\issue\issue now +control
+cisis\mx temp\serial\section\section now +control


### PR DESCRIPTION
Criação da pasta temp no inicio do processamento
Considerar que o acronimo na base issue e section nao necessarimante está em caixa alta.
