### PR TITLE
Não apagar os arquivos do scielo_package e pmc_package (#409)

### DIFF
--- a/src/scielo/bin/xml/xmlpkgmker.py
+++ b/src/scielo/bin/xml/xmlpkgmker.py
@@ -2334,13 +2334,15 @@ class XPM5(object):
     def make_packages(self, files, ctrl_filename, work_path, scielo_val_res, pmc_val_res):
         old_names = {}
 
-        for path in [scielo_val_res.pkg_path, pmc_val_res.pkg_path]:
-            if os.path.isdir(path):
-                for f in os.listdir(path):
-                    if os.path.isfile(path + '/' + f):
-                        os.unlink(path + '/' + f)
-            else:
-                os.makedirs(path)
+        if len(files) == 1:
+            if not files[0].endswith('.sgm.xml'):
+                for path in [scielo_val_res.pkg_path, pmc_val_res.pkg_path]:
+                    if os.path.isdir(path):
+                        for f in os.listdir(path):
+                            if os.path.isfile(path + '/' + f):
+                                os.unlink(path + '/' + f)
+                    else:
+                        os.makedirs(path)
 
         for xml_filename in files:
             xml_path = os.path.dirname(xml_filename)


### PR DESCRIPTION
Antes de gerar qualquer XML pelo Markup, os arquivos das pastas scielo_package e pmc_package eram apagados
