### PR TITLE
Melhoria na documentação para <ref>

### DIFF
--- a/docs/source/pt_guidelines_xml.rst
+++ b/docs/source/pt_guidelines_xml.rst
@@ -1751,8 +1751,8 @@ A estrutura geral que abarca a lista de referências deve conter quatro tags pri
                    <fpage>página inicial</fpage>
                    <lpage>página final</lpage>        
       <pub-id pub-id-type="pmid">somente números</pub-id>
-      <pub-id pub-id-type="pcmid">somente números</pub-id>
-      <pub-id pub-id-type="doi">somente números</pub-id>
+      <pub-id pub-id-type="pmcid">somente números</pub-id>
+      <pub-id pub-id-type="doi">somente o identificador</pub-id>
       <pub-id pub-id-type="pii">somente números</pub-id>
      <elocation-id>representa um número de página eletrônica</elocation-id>
        </element-citation>


### PR DESCRIPTION
- corrigido erro de digitação do pmcid e melhorada explicação para o doi
- tag <article-id> não é permitida dentro do <element-citation>. A tag correta é <pub-id> conforme http://jats.nlm.nih.gov/publishing/tag-library/1.0/n-t2u0.html
