### PR TITLE
Removido o atributo ftype de fig, por decidir que é desnecessário

### DIFF
--- a/src/scielo/bin/markup_xml/app_core/link.mds
+++ b/src/scielo/bin/markup_xml/app_core/link.mds
@@ -68,7 +68,7 @@ tabwrap
 id
 
 figgrp
-id;ftype
+id
 
 figgrps
 id


### PR DESCRIPTION
Fixes #629
