### PR TITLE
Corrige o relatório que erroneamente indica falta de imagem no pacote.

### DIFF
--- a/src/scielo/bin/xml/modules/article.py
+++ b/src/scielo/bin/xml/modules/article.py
@@ -56,18 +56,21 @@ class HRef(object):
         if element.attrib.get('ext-link-type') is not None or element.tag in ['license', 'ext-link', 'uri', 'related-article']:
             self.is_internal_file = False
 
-    def filename(self, path):
-        _href = None
+    def file_location(self, path):
+        location = None
         if self.src is not None and self.src != '':
             if self.is_internal_file:
-                _href = path + '/' + self.src
+                location = path + '/' + self.src
 
                 if self.is_image:
-                    if _href.endswith('.tiff'):
-                        _href = _href.replace('.tiff', '.jpg')
-                    elif _href.endswith('.tif'):
-                        _href = _href.replace('.tif', '.jpg')
-        return _href
+                    if location.endswith('.tiff'):
+                        location = location.replace('.tiff', '.jpg')
+                    elif location.endswith('.tif'):
+                        location = location.replace('.tif', '.jpg')
+                    else:
+                        if location[-5:-4] != '.' and location[-4:-3] != '.':
+                            location += '.jpg'
+        return location
 
 
 class PersonAuthor(object):

--- a/src/scielo/bin/xml/modules/article_reports.py
+++ b/src/scielo/bin/xml/modules/article_reports.py
@@ -11,6 +11,13 @@ import html_reports
 from article import Article, PersonAuthor, CorpAuthor, format_author
 
 
+log_items = []
+
+
+def register_log(text):
+    log_items.append(datetime.now().isoformat() + ' ' + text)
+
+
 class TOCReport(object):
 
     def __init__(self, articles, validate_order):
@@ -513,7 +520,7 @@ class ArticleSheetData(object):
                 row['href'] = hrefitem.src
 
                 if hrefitem.is_internal_file:
-                    filename = 'file:///' + hrefitem.filename(path)
+                    filename = 'file:///' + hrefitem.file_location(path)
                 else:
                     filename = hrefitem.src
 
@@ -595,35 +602,77 @@ def toc_report_data(articles, validate_order):
 
 
 def get_report_content(article, new_name, package_path, validate_order, display_all):
+    register_log('get_report_content: inicio')
     if article is None:
         content = 'FATAL ERROR: Unable to get data of ' + new_name + '.'
         sheet_data = None
     else:
+        print('validating contents 1')
+        register_log('get_report_content: article_validations.ArticleContentValidation')
         article_validation = article_validations.ArticleContentValidation(article, validate_order)
-        sheet_data = ArticleSheetData(article, article_validation)
-        article_display_report = ArticleDisplayReport(article, sheet_data, package_path, new_name)
-        article_validation_report = ArticleValidationReport(article_validation)
-        content = validate_contents(article_display_report, article_validation_report, display_all)
 
-    return (content, sheet_data)
+        print('validating contents 2')
+        register_log('get_report_content: ArticleSheetData')
+        sheet_data = ArticleSheetData(article, article_validation)
+
+        print('validating contents 3')
+        register_log('get_report_content: ArticleDisplayReport')
+        article_display_report = ArticleDisplayReport(article, sheet_data, package_path, new_name)
+
+        print('validating contents 4')
+        register_log('get_report_content: ArticleValidationReport')
+        article_validation_report = ArticleValidationReport(article_validation)
+
+        print('validating contents 5')
+        register_log('get_report_content: validate_contents')
+        content = validate_contents(article_display_report, article_validation_report, display_all)
+    register_log('get_report_content: fim')
+
+    return (content, sheet_data, log_items)
 
 
 def validate_contents(data_display, data_validation, display_all):
     content = []
+    n = 0
     #if display_all:
+    register_log('validate_contents: data_display.summary')
+    print('validate_contents: ' + str(n))
+    n += 1
     content.append(data_display.summary)
-
+    register_log('validate_contents: data_validation.validations')
+    print('validate_contents: ' + str(n))
+    n += 1
     content.append(data_validation.validations(not display_all))
+    register_log('validate_contents: data_display.files_and_href')
+    print('validate_contents: ' + str(n))
+    n += 1
     content.append(data_display.files_and_href)
 
     if display_all:
+        register_log('validate_contents: data_display.article_body')
+        print('validate_contents: ' + str(n))
+        n += 1
         content.append(data_display.article_body)
-        content.append(data_display.article_back)
-        #content.append(data_display.id_and_tag_list
-        content.append(data_display.authors_sheet)
-        content.append(data_display.sources_sheet)
 
-    return html_reports.join_texts(content)
+        register_log('validate_contents: data_display.article_back')
+        print('validate_contents: ' + str(n))
+        n += 1
+        content.append(data_display.article_back)
+
+        register_log('validate_contents: data_display.authors_sheet')
+        print('validate_contents: ' + str(n))
+        n += 1
+        content.append(data_display.authors_sheet)
+
+        register_log('validate_contents: data_display.sources_sheet')
+        print('validate_contents: ' + str(n))
+        n += 1
+        content.append(data_display.sources_sheet)
+        print('validate_contents: ' + str(n))
+
+    res = html_reports.join_texts(content)
+    print('validate_contents: fim')
+    return res
 
 
 def example():

--- a/src/scielo/bin/xml/modules/article_validations.py
+++ b/src/scielo/bin/xml/modules/article_validations.py
@@ -161,6 +161,7 @@ class ArticleContentValidation(object):
 
     @property
     def validations(self):
+        print('validations: 1')
         items = [self.journal_title,
                     self.publisher_name,
                     self.journal_id,
@@ -193,7 +194,10 @@ class ArticleContentValidation(object):
                     self.validate_xref_reftype,
                     self.missing_xref_list
                 ]
-        return self.normalize_validations(items)
+        print('validations: 2')
+        r = self.normalize_validations(items)
+        print('validations: 3')
+        return r
 
     @property
     def dtd_version(self):
@@ -646,25 +650,12 @@ class ArticleContentValidation(object):
     def href_list(self, path):
         href_items = {'ok': [], 'warning': [], 'error': [], 'fatal error': []}
         for hrefitem in self.article.hrefs:
-            filename = hrefitem.src
             if hrefitem.is_internal_file:
-                filename = hrefitem.filename(path)
-                if os.path.isfile(filename):
+                file_location = hrefitem.file_location(path)
+                if os.path.isfile(file_location):
                     href_items['ok'].append(hrefitem)
                 else:
-                    if filename.endswith('.tiff') or filename.endswith('.tif'):
-                        if os.path.isfile(filename[0:filename.rfind('.')] + '.jpg'):
-                            href_items['ok'].append(hrefitem)
-                        else:
-                            href_items['fatal error'].append(hrefitem)
-                    else:
-                        if not '.' in filename[-5:]:
-                            if os.path.isfile(filename + '.jpg'):
-                                href_items['warning'].append(hrefitem)
-                            else:
-                                href_items['fatal error'].append(hrefitem)
-                        else:
-                            href_items['fatal error'].append(hrefitem)
+                    href_items['fatal error'].append(hrefitem)
             else:
                 if article_utils.url_check(hrefitem.src, 10):
                     href_items['ok'].append(hrefitem)

--- a/src/scielo/bin/xml/modules/xpchecker.py
+++ b/src/scielo/bin/xml/modules/xpchecker.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+from datetime import datetime
 
 try:
     from packtools.catalogs import XML_CATALOG
@@ -7,9 +8,17 @@ try:
 except:
     os.environ['XML_CATALOG_FILES'] = ''
 
+
 import java_xml_utils
 import xml_utils
 import html_reports
+
+
+log_items = []
+
+
+def register_log(text):
+    log_items.append(datetime.now().isoformat() + ' ' + text)
 
 
 def save_packtools_style_report(content, report_filename):
@@ -52,11 +61,15 @@ def packtools_style_validation(xml_filename, report_filename):
 
 
 def java_xml_utils_dtd_validation(xml_filename, report_filename, doctype):
-    return java_xml_utils.xml_validate(xml_filename, report_filename, doctype)
+    register_log('java_xml_utils_dtd_validation: inicio')
+    r = java_xml_utils.xml_validate(xml_filename, report_filename, doctype)
+    register_log('java_xml_utils_dtd_validation: fim')
+    return r
 
 
 def java_xml_utils_style_validation(xml_filename, doctype, report_filename, xsl_prep_report, xsl_report):
     # STYLE CHECKER REPORT
+    register_log('java_xml_utils_style_validation: inicio')
     is_valid_style = False
     xml_report = report_filename.replace('.html', '.xml')
     if os.path.exists(xml_report):
@@ -80,6 +93,7 @@ def java_xml_utils_style_validation(xml_filename, doctype, report_filename, xsl_
 
     if os.path.isfile(xml_report):
         os.unlink(xml_report)
+    register_log('java_xml_utils_style_validation: fim')
     return is_valid_style
 
 
@@ -141,8 +155,10 @@ def style_validation(xml_filename, doctype, report_filename, xsl_prep_report, xs
 
 
 def validate_article_xml(xml_filename, dtd_files, dtd_report_filename, style_report_filename):
+    register_log('validate_article_xml: inicio')
     is_valid_style = False
 
+    register_log('validate_article_xml: inicio')
     xml, e = xml_utils.load_xml(xml_filename)
     is_valid_dtd = dtd_validation(xml_filename, dtd_report_filename, dtd_files.doctype_with_local_path, dtd_files.database_name)
     if e is None:
@@ -150,4 +166,6 @@ def validate_article_xml(xml_filename, dtd_files, dtd_report_filename, style_rep
     else:
         open(style_report_filename, 'w').write('FATAL ERROR: Unable to load ' + xml_filename + '\n' + str(e))
     f, e, w = style_checker_statistics(style_report_filename)
+    register_log('validate_article_xml: fim')
+    open(os.path.dirname(style_report_filename) + '/validate_article_xml.log', 'a+').write('\n'.join(log_items))
     return (xml, is_valid_dtd, (f, e, w))


### PR DESCRIPTION
Fixes #1282

e também
Refatora a forma de coletar os arquivos para o pacote
Tenta encontrar pontos de pior desempenho no processo completo