### PR TITLE
Corrige validação do prefix do id bx, subdoc, e figgrp

### DIFF
--- a/src/scielo/bin/SGMLPars/common4_0.dtd
+++ b/src/scielo/bin/SGMLPars/common4_0.dtd
@@ -82,7 +82,7 @@ filename       CDATA #IMPLIED>
 <!ATTLIST figgrps
           id       CDATA #REQUIRED
           >
-<!ELEMENT figgrp - - (  graphic, notes?, ( label?, caption)?   )   >
+<!ELEMENT figgrp - - (  graphic, notes?, alttext?, attrib?, ( label?, caption)?   )   >
 <!ATTLIST figgrp
           id       CDATA #REQUIRED
           ftype       CDATA #IMPLIED 
@@ -92,12 +92,12 @@ filename       CDATA #IMPLIED>
 <!ATTLIST equation
           id       CDATA #REQUIRED>
 
-<!ELEMENT element - - (attrib*, element*)   >
+<!ELEMENT element - - (elemattr*, element*)   >
 <!ATTLIST element
           name       CDATA #REQUIRED>
 
-<!ELEMENT attrib  - - (#PCDATA) >
-<!ATTLIST attrib
+<!ELEMENT elemattr  - - (#PCDATA) >
+<!ATTLIST elemattr
           name CDATA #REQUIRED 
           value CDATA #REQUIRED>
 

--- a/src/scielo/bin/markup_xml/app_core/link.mds
+++ b/src/scielo/bin/markup_xml/app_core/link.mds
@@ -121,7 +121,7 @@ ctrbidtp
 element
 name
 
-attrib
+elemattr
 name;value
 
 supplmat

--- a/src/scielo/bin/markup_xml/app_core/tree.txt
+++ b/src/scielo/bin/markup_xml/app_core/tree.txt
@@ -137,7 +137,7 @@ back;#FALSE#;#FALSE#
 response;#FALSE#;#TRUE#
 subart;#FALSE#;#TRUE#
 
-attrib
+elemattr
 
 app
 sectitle;#FALSE#;#FALSE#
@@ -248,7 +248,7 @@ dperiod
 edition
 
 element
-attrib;#FALSE#;#TRUE#
+elemattr;#FALSE#;#TRUE#
 
 email
 
@@ -262,10 +262,11 @@ et-al
 extent
 
 figgrp
-label;#FALSE#;#FALSE#
-caption;#FALSE#;#FALSE#
 graphic;#FALSE#;#FALSE#
 alttext;#FALSE#;#FALSE#
+attrib;#TRUE#;#FALSE#
+label;#FALSE#;#FALSE#
+caption;#FALSE#;#FALSE#
 
 figgrps
 label;#FALSE#;#FALSE#
@@ -1068,11 +1069,11 @@ series
 versegrp
 versline;#FALSE#;#TRUE#
 versegrp;#FALSE;#TRUE#
-attrb;#FALSE;#TRUE#
+attrib;#FALSE;#TRUE#
 
 versline
 
-attrb
+attrib
 
 alttitle
 

--- a/src/scielo/bin/markup_xml/app_core/tree_en.txt
+++ b/src/scielo/bin/markup_xml/app_core/tree_en.txt
@@ -196,8 +196,8 @@ appgrp;Identify a group of appendixes
 series;Identify series
 versegrp;Identify song, poem, or verse
 versline;Identify a song, poem, or verse line
-attrb;Identify information concerning the origin of an extract, display quote, poetry, or similar element.
+attrib;Identify information concerning the origin of an extract, display quote, poetry, or similar element.
 alttext;Identify an alternative text for a graphic or figure
 alttitle;Identify an alternative title for the document title
 element;Identify any element of XML
-attrib;Identify any attribute of XML
+elemattr;Identify any attribute of XML

--- a/src/scielo/bin/markup_xml/app_core/tree_pt.txt
+++ b/src/scielo/bin/markup_xml/app_core/tree_pt.txt
@@ -196,8 +196,8 @@ appgrp;Identifica um grupo de apêndices
 series;Identifica seriada
 versegrp;Identifica canção, poema, verso
 versline;Identifica líneas de canção, poema, verso
-attrb;Identifica informação relacionada com a origem de uma citação, poesia, ou similar.
+attrib;Identifica informação relacionada com a origem de uma citação, poesia, ou similar.
 alttext;Identifica um texto alternativo para descrever uma imagem.
 alttitle;Identifica um título alternativo do documento
 element;Identifica quaisquer elementos de XML
-attrib;Identifica quaisquer attributos de XML
+elemattr;Identifica quaisquer attributos de XML

--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -3198,10 +3198,10 @@ et al.</copyright-statement>
 	</xsl:template>
 	<xsl:template match="element">
 		<xsl:element name="{@name}">
-			<xsl:apply-templates select="attrib|element|text()"/>
+			<xsl:apply-templates select="*|text()"/>
 		</xsl:element>
 	</xsl:template>
-	<xsl:template match="attrib">
+	<xsl:template match="elemattr">
 		<xsl:attribute name="{@name}">
 			<xsl:apply-templates select="@value"/>
 		</xsl:attribute>
@@ -3521,10 +3521,6 @@ et al.</copyright-statement>
 	
 	<xsl:template match="versline">
 		<verse-line><xsl:apply-templates select="@*|*|text()"/></verse-line>
-	</xsl:template>
-	
-	<xsl:template match="attrb">
-		<attrib><xsl:apply-templates select="@*|*|text()"/></attrib>
 	</xsl:template>
 	
 	<xsl:template match="alttitle">


### PR DESCRIPTION
Também corrige a tag attrib, element, attr de element.
attrib deve aparecer tambem para figgrp

Fixes #1303
Fixes #1299
Fixes #1296