### PR TITLE
Download do markup

### DIFF
--- a/src/scielo/bin/xml/download_markup_journals.py
+++ b/src/scielo/bin/xml/download_markup_journals.py
@@ -31,9 +31,6 @@ def journals_by_collection(filename):
                     if not _col in collections.keys():
                         collections[_col] = []
                     collections[_col].append(j)
-            else:
-                print('ignored:')
-                print(item)
         if 'Symbol' in collections.keys():
             del collections['Symbol']
         if 'Collection Name' in collections.keys():
@@ -69,7 +66,7 @@ def get_collection_journals_list(collections, collection_name):
         column.append(item['pissn'])
         column.append(item['eissn'])
         column.append(item['publisher-name'])
-        journals[item['journal-title'].lower()] = '|'.join(column)
+        journals[item['journal-title'].lower()] = collection_name + '|' + '|'.join(column)
     return journals
 
 
@@ -86,7 +83,7 @@ def get_all_journals_list(collections):
             column.append(item['pissn'])
             column.append(item['eissn'])
             column.append(item['publisher-name'])
-            journals[item['journal-title'].lower()] = '|'.join(column)
+            journals[item['collection-name'].lower() + ' | ' + item['journal-title'].lower()] = collection_key + '|' + '|'.join(column)
     return journals
 
 

--- a/src/scielo/bin/xml/modules/article_validations.py
+++ b/src/scielo/bin/xml/modules/article_validations.py
@@ -123,7 +123,7 @@ def validate_surname(label, value):
         suffix_list = [u'Nieto', u'Sobrino', u'Hijo', u'Neto', u'Sobrinho', u'Filho', u'Júnior', u'JÚNIOR', u'Junior', u'Senior', u'Sr', u'Jr']
 
         parts = value.split(' ')
-        if len(parts) > 1:
+        if len(parts) > 0:
             rejected = [item for item in parts if item in suffix_list]
             suffix = ' '.join(rejected)
 
@@ -839,6 +839,8 @@ class ReferenceContentValidation(object):
                 self.validate_element('volume', self.reference.volume), 
                 self.validate_element('issue', self.reference.issue), 
                 self.validate_element('fpage', self.reference.fpage), 
+                self.validate_element('source', self.reference.source), 
+                self.validate_element('year', self.reference.year), 
             ]
 
         _mixed = self.reference.mixed_citation.lower()


### PR DESCRIPTION
Fixes #1534 
O download não pode ser via Markup porque nem todas as coleções tem esta funcionalidade. Por enquanto, esta lista tem que ser atualizada manualmente.