### PR TITLE
Fix generate inline-graphic on inline-formula

### DIFF
--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -2737,7 +2737,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 			<xsl:apply-templates select="." mode="graphic"/>
 		</inline-formula>
 	</xsl:template>
-	<xsl:template match="p/graphic | caption/graphic | li/graphic">
+	<xsl:template match="p/graphic | caption/graphic | li/graphic | p/equation//graphic">
 		<inline-graphic>
 			<xsl:apply-templates select="@*"/>
 		</inline-graphic>


### PR DESCRIPTION
No se generaba correctamente la etiqueta  ```inline-graphic``` dentro de ```inline-formula```
![screen shot 2015-08-21 at 11 46 32](https://cloud.githubusercontent.com/assets/197827/9413992/e3727dc6-47fa-11e5-96e0-821160f7af9c.png)
![screen shot 2015-08-21 at 11 48 42](https://cloud.githubusercontent.com/assets/197827/9413996/e7302d64-47fa-11e5-9a12-8133e423d6f6.png)

