### PR TITLE
Check if label is part of text-ref

### DIFF
--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1953,7 +1953,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 	<xsl:template match="*[contains(name(),'citat')]| ref" mode="mixed-citation">
 		<mixed-citation>
 			<xsl:choose>
-				<xsl:when test="text-ref and label and not(text-ref/*)">
+				<xsl:when test="text-ref and label and not(text-ref/*) and contains(text-ref, label)">
 					<xsl:value-of select="substring-after(text-ref,label)"/>
 				</xsl:when>
 				<xsl:when test="text-ref">


### PR DESCRIPTION
Este caso solo ocurre con documentos que nos manda Elsevier, en los cuales el valor de ```[label]``` no es parte de ```[text-ref]```
![screen shot 2015-08-24 at 13 28 34](https://cloud.githubusercontent.com/assets/197827/9448808/4888c056-4a64-11e5-94ee-fa09d1596489.png)
![screen shot 2015-08-24 at 13 24 05](https://cloud.githubusercontent.com/assets/197827/9448812/4d34613c-4a64-11e5-96f8-59317f405c8c.png)
