### PR TITLE
Ajustes

### DIFF
--- a/src/scielo/bin/cfg/version.txt
+++ b/src/scielo/bin/cfg/version.txt
@@ -1,11 +1,15 @@
 ﻿4.0.090 trial - 14/09/2015
 ==========================
  - (bug) Solve encoding problem which occurres in some computers as reading the DTD report
+ - (bug) Fix the article title to check doi
+ - (bug) Fix message of missing tiff (the correct is missing jpg generated from tiff)
+ - (improvement) Ignore city/state to have a perfect match as normalizing the institution name 
 
 4.0.090 trial - 08/09/2015
 ==========================
 - Markup
   - (new) Identify xmlbody which starts with p and subsec
+  - (bug) Chinese abbreviation must be zh, instead of ch
 - XC
   - (bug) Fix name of PDF (0104-530X-gp-0104-530X1387-14 was renamed to 14_0104-530X-gp-0104-530X1387)
   - (new) Reorganize Converter messages

--- a/src/scielo/bin/cfg/xpm_version.txt
+++ b/src/scielo/bin/cfg/xpm_version.txt
@@ -1,6 +1,9 @@
 ﻿4.0.090 trial - 14/09/2015
 ==========================
  - (bug) Solve encoding problem which occurres in some computers as reading the DTD report
+ - (bug) Fix the article title to check doi
+ - (bug) Fix message of missing tiff (the correct is missing jpg generated from tiff)
+ - (improvement) Ignore city/state to have a perfect match as normalizing the institution name 
 
 4.0.090 trial - 08/09/2015
 ==========================

--- a/src/scielo/bin/xml/modules/article_reports.py
+++ b/src/scielo/bin/xml/modules/article_reports.py
@@ -426,28 +426,16 @@ class ArticleSheetData(object):
     def hrefs_sheet_data(self, path):
         t_header = ['href', 'display', 'xml']
         r = []
-        for status, href_items in self.article_validation.href_list(path).items():
-            for hrefitem in href_items:
+        href_items = self.article_validation.href_list(path)
+        for src in sorted(href_items.keys()):
+            hrefitem = href_items.get(src)
+            if hrefitem['elem'].is_internal_file:
                 row = {}
-                row['href'] = hrefitem.src
-                hreflocation = hrefitem.src if not hrefitem.is_internal_file else 'file:///' + hrefitem.file_location(path)
-
-                row['display'] = ''
-                if hrefitem.is_image:
-                    row['display'] = html_reports.image(hreflocation)
-                else:
-                    row['display'] = html_reports.link(hreflocation, hrefitem.src)
-
-                if not status == 'ok':
-                    if hrefitem.is_internal_file:
-                        if status == 'warning':
-                            row['display'] += status.upper() + ': ' + _('missing extension of ') + hrefitem.src + '.'
-                        else:
-                            row['display'] += status.upper() + ': ' + hrefitem.src + _(' not found in package')
-                    else:
-                        row['display'] += status.upper() + ': ' + hrefitem.src + _(' is not working')
-
-                row['xml'] = hrefitem.xml
+                row['href'] = src
+                row['display'] = hrefitem['display']
+                if hrefitem['status'] != 'OK':
+                    row['display'] += hrefitem['status'] + ': ' + hrefitem['msg']
+                row['xml'] = hrefitem['elem'].xml
                 r.append(row)
         return (t_header, ['display', 'xml'], r)
 

--- a/src/scielo/bin/xml/modules/article_validations.py
+++ b/src/scielo/bin/xml/modules/article_validations.py
@@ -9,7 +9,7 @@ import article_utils
 import xml_utils
 import utils
 import article
-
+import html_reports
 import institutions_service
 
 
@@ -413,11 +413,14 @@ class ArticleContentValidation(object):
                 max_rate = 0
                 selected = None
                 for t in self.article.titles:
-                    rate, items = utils.most_similar(utils.similarity(article_titles, t.title))
+                    rate, items = utils.most_similar(utils.similarity(article_titles, xml_utils.remove_tags(t.title)))
                     if rate > max_rate:
                         max_rate = rate
                 if max_rate < 0.7:
                     status = 'FATAL ERROR'
+                    print(article_titles)
+                    for t in self.article.titles:
+                        print(xml_utils.remove_tags(t.title))
 
                 r.append(('doi', status, self.article.doi + ' ' + _('is already registered to') + ' ' + '|'.join(article_titles)))
 
@@ -601,7 +604,7 @@ class ArticleContentValidation(object):
                         status = 'ERROR'
                         r.append(('normalized aff', status, _('Similar normalized institution names: ') + orgname + ', ' + country_code + ' (' + ', '.join([orgname, city, state, country_code, country_name]) + ')'))
                 else:
-                    msg = _('Unable to confirm/find the normalized institution name for ') + ' or '.join(item for item in [aff.orgname, aff.norgname] if item is not None)
+                    msg = _('Unable to confirm/find the normalized institution name for ') + ' or '.join(item for item in list(set([aff.orgname, aff.norgname])) if item is not None)
                     if len(normalized_items) == 0:
                         r.append(('normalized aff', 'ERROR', msg + _('. Ask for normalized institution name by email: scielo-xml@googlegroups.com')))
                     else:
@@ -936,7 +939,7 @@ class ArticleContentValidation(object):
 
         return message
 
-    def href_list(self, path):
+    def old_href_list(self, path):
         href_items = {'ok': [], 'warning': [], 'error': [], 'fatal error': []}
         for hrefitem in self.article.hrefs:
             if hrefitem.is_internal_file:
@@ -956,6 +959,40 @@ class ArticleContentValidation(object):
                         href_items['warning'].append(hrefitem)
                 #else:
                 #    href_items['ok'].append(hrefitem)
+        return href_items
+
+    def href_list(self, path):
+        href_items = {}
+        for hrefitem in self.article.hrefs:
+            status = 'OK'
+            message = ''
+            if hrefitem.is_internal_file:
+                file_location = hrefitem.file_location(path)
+                if os.path.isfile(file_location):
+                    if not '.' in hrefitem.src:
+                        message = _('missing extension of ') + hrefitem.src + '.'
+                        status = 'WARNING'
+                else:
+                    if file_location.endswith(hrefitem.src):
+                        message = hrefitem.src + _(' not found in package')
+                        status = 'FATAL ERROR'
+                    elif file_location.endswith('.jpg') and (hrefitem.src.endswith('.tif') or hrefitem.src.endswith('.tiff')):
+                        message = os.path.basename(file_location) + _(' not found in package')
+                        status = 'FATAL ERROR'
+                hreflocation = 'file:///' + file_location
+            else:
+                hreflocation = hrefitem.src
+                if self.check_url:
+                    if not article_utils.url_check(hrefitem.src, 1):
+                        status = 'WARNING'
+                        message = hrefitem.src + _(' is not working')
+
+            if hrefitem.is_image:
+                display = html_reports.image(hreflocation)
+            else:
+                display = html_reports.link(hreflocation, hrefitem.src)
+
+            href_items[hrefitem.src] = {'display': display, 'msg': message, 'status': status, 'elem': hrefitem}
         return href_items
 
 

--- a/src/scielo/bin/xml/modules/institutions_service.py
+++ b/src/scielo/bin/xml/modules/institutions_service.py
@@ -268,14 +268,17 @@ def get_normalized_from_wayta(orgname, country):
 
 def validate_organization(org_manager, orgname, norgname, country_name, country_code, state, city):
     orgname_and_location_items = []
-    if norgname is not None:
-        orgname_and_location_items += org_manager.get_institutions(norgname, city, state, country_code, country_name)
+    for name in list(set([orgname, norgname])):
+        if name is not None:
+            orgname_and_location_items += org_manager.get_institutions(name, city, state, country_code, country_name)
 
-    if not len(orgname_and_location_items) == 1:
-        if orgname is not None:
-            orgname_and_location_items += org_manager.get_institutions(orgname, city, state, country_code, country_name)
-
-    return list(set(orgname_and_location_items))
+    orgname_and_location_items = list(set(orgname_and_location_items))
+    if len(orgname_and_location_items) > 1:
+        fixed = []
+        for orgname, city, state, country_code, country_name in orgname_and_location_items:
+            fixed.append((orgname, '', '', country_code, country_name))
+        orgname_and_location_items = list(set(fixed))
+    return orgname_and_location_items
 
 
 def get_similars_from_normalized_list_for_wayta(org_manager, orgname, country_name):

--- a/src/scielo/bin/xml/modules/xml_utils.py
+++ b/src/scielo/bin/xml/modules/xml_utils.py
@@ -195,6 +195,8 @@ def node_xml(node):
     text = None
     if not node is None:
         text = etree.tostring(node)
+        if '&' in text:
+            text, replaced_named_ent = convert_entities_to_chars(text)
     return text
 
 


### PR DESCRIPTION
 - ajuste no título do artigo para comparar com o título do artigo registrado para o DOI (título iguais eram considerados diferentes devido à formatação ou codificação de caracteres)
 - melhoria na validação de nomes de instituições, desconsiderar city/state
 - corrige mensagem de imagem não encontrada (tiff estava no pacote mas era indicado sua ausencia, o correto era indicar a ausencia de jpg correspondente ao tiff)