### PR TITLE
exclusao de palavra duplicada

### DIFF
--- a/docs/source/pt_how_to_generate_xml-markup.rst
+++ b/docs/source/pt_how_to_generate_xml-markup.rst
@@ -7,7 +7,7 @@ Como usar o Markup
 Introdução
 ==========
 
-Este manual tem como objetivo apresentar o uso do programa de marcação Markup `Markup <markup.html>`_ 
+Este manual tem como objetivo apresentar o uso do programa de marcação `Markup <markup.html>`_ 
 
 
 .. _sugestao-id:


### PR DESCRIPTION
Exclusão da palavra "Markup" duplicada no início da documentação de "Como usar o Markup".