### PR TITLE
Alteração de nota em rolling pass

### DIFF
--- a/docs/source/pt_how_to_generate_xml-markup.rst
+++ b/docs/source/pt_how_to_generate_xml-markup.rst
@@ -2316,7 +2316,7 @@ A indicação de página eletrônica do documento deve ser inserida no campo [el
    :align: center
 
 
-.. note:: Arquivos RP apresentam elocation, portanto não apresenta fpage e lpage, devendo ser inserido a informação 00 em cada.
+.. note:: Arquivos RP apresentam elocation, portanto não apresenta fpage e lpage.
 
 
 .. _resenha:


### PR DESCRIPTION
Alteração de nota errada em rolling pass
.. note:: Arquivos RP apresentam elocation, portanto não apresenta fpage e lpage, devendo ser inserido a informação 00 em cada.

Para:
.. note:: Arquivos RP apresentam elocation, portanto não apresenta fpage e lpage.