### PR TITLE
Corrige texto de formatação para citação numérica

### DIFF
--- a/docs/source/es_how_to_generate_xml-prepara.rst
+++ b/docs/source/es_how_to_generate_xml-prepara.rst
@@ -118,7 +118,7 @@ Para optimizar el proceso de marcaje de los elementos básicos do archivo, es ne
  * Separador de label y caption: dos-puntos e espacio o espacio + guion + espacio o ponto + espacio;
  * Para tablas codificadas, el encabezamiento debe estar en negrita;
  * La cita del tipo autor/fecha en el cuerpo del texto debe ser: sobrenombre del autor, año;
- * Para citas en el sistema numérico en el cuerpo del texto: número entre parénteses y ambos con formateo "sobrescrito";
+ * Para citas en el sistema numérico en el cuerpo del texto: número entre parénteses y ambos con formateo "sobrescrito". Ej: :sup:`(1)`, :sup:`(1-8)`, :sup:`(1,3-5)`;
  * Notas de pie de página en el cuerpo del texto pueden estar “sobrescrito", pero no estarán entre paréntesis;
  * Citaciones (quote), reculado en 4 cm de la margen izquierda;
 

--- a/docs/source/es_how_to_generate_xml-prepara.rst
+++ b/docs/source/es_how_to_generate_xml-prepara.rst
@@ -1,4 +1,4 @@
-
+﻿
 `Português <pt_how_to_generate_xml-prepara.html>`_ | `English <how_to_generate_xml-prepara.html>`_ 
 
 
@@ -118,7 +118,7 @@ Para optimizar el proceso de marcaje de los elementos básicos do archivo, es ne
  * Separador de label y caption: dos-puntos e espacio o espacio + guion + espacio o ponto + espacio;
  * Para tablas codificadas, el encabezamiento debe estar en negrita;
  * La cita del tipo autor/fecha en el cuerpo del texto debe ser: sobrenombre del autor, año;
- * Para citas en el sistema numérico en el cuerpo del texto: "sobrescrito" e entre paréntesis;
+ * Para citas en el sistema numérico en el cuerpo del texto: número entre parénteses y ambos con formateo "sobrescrito";
  * Notas de pie de página en el cuerpo del texto pueden estar “sobrescrito", pero no estarán entre paréntesis;
  * Citaciones (quote), reculado en 4 cm de la margen izquierda;
 

--- a/docs/source/how_to_generate_xml-prepara.rst
+++ b/docs/source/how_to_generate_xml-prepara.rst
@@ -118,7 +118,7 @@ Para otimizar o processo de marcação dos elementos básicos do arquivo, é nec
  * Separador de label e caption: dois-pontos e espaço ou espaço + hífen + espaço ou ponto + espaço;
  * Para tabelas codificadas, o cabeçalho deve estar em negrito;
  * A citação de autor/data no corpo do texto deve ser: sobrenome do autor, ano;
- * Para citação no sistema numérico no corpo do texto: número(s) entre parênteses, ambos com formato sobrescrito;
+ * Para citação no sistema numérico no corpo do texto: número(s) entre parênteses, ambos com formato sobrescrito. Ex: :sup:`(1)`, :sup:`(1-8)`, :sup:`(1,3-5)`;
  * Notas de rodapé no corpo do texto podem estar em "sup", mas não estarão entre parênteses;
  * Citações (quote), recuo de 4 cm da margem esquerda;
 

--- a/docs/source/how_to_generate_xml-prepara.rst
+++ b/docs/source/how_to_generate_xml-prepara.rst
@@ -1,4 +1,4 @@
-
+﻿
 
 `Español <es_how_to_generate_xml-prepara.html>`_ | `Português <pt_how_to_generate_xml-prepara.html>`_ 
 
@@ -118,7 +118,7 @@ Para otimizar o processo de marcação dos elementos básicos do arquivo, é nec
  * Separador de label e caption: dois-pontos e espaço ou espaço + hífen + espaço ou ponto + espaço;
  * Para tabelas codificadas, o cabeçalho deve estar em negrito;
  * A citação de autor/data no corpo do texto deve ser: sobrenome do autor, ano;
- * Para citação no sistema numérico no corpo do texto: "sup" e entre parênteses;
+ * Para citação no sistema numérico no corpo do texto: número(s) entre parênteses, ambos com formato sobrescrito;
  * Notas de rodapé no corpo do texto podem estar em "sup", mas não estarão entre parênteses;
  * Citações (quote), recuo de 4 cm da margem esquerda;
 


### PR DESCRIPTION
Fixes #2504 altera texto para esclarecer que ambos (parênteses e número citado) devem estar com formato sobrescrito.