### PR TITLE
40094_tk2597

### DIFF
--- a/src/scielo/bin/xml/modules/app/data/article.py
+++ b/src/scielo/bin/xml/modules/app/data/article.py
@@ -268,7 +268,6 @@ class ContribXML(object):
         self._contrib = None
         self.fnames = self.xml_node.nodes_text(['.//given-names'])
         self.surnames = self.xml_node.nodes_text(['.//surname'])
-        self.anonymous = self.xml_node.nodes_text(['.//anonymous'])
         self.suffixes = self.xml_node.nodes_text(['.//suffix'])
         self.prefixes = self.xml_node.nodes_text(['.//prefix'])
         self.contrib_id_items = self.xml_node.nodes_data(['.//contrib-id'])
@@ -282,8 +281,9 @@ class ContribXML(object):
 
     @property
     def anonymous_author(self):
-        if len(self.anonymous) > 0:
+        if self.node.tag == 'anonymous':
             return AnonymousAuthor('anonymous')
+        return self.xml_node.nodes_xml(['.//anonymous'])
 
     @property
     def person_author(self):
@@ -2002,11 +2002,17 @@ class ReferenceXML(object):
         return self._contrib_xml_items
 
     @property
+    def person_group_nodes(self):
+        if not hasattr(self, '_person_group_nodes'):
+            self._person_group_nodes = self.root_xml_node.nodes(['.//person-group'])
+        return self._person_group_nodes
+
+    @property
     def person_group_xml_items(self):
         if self._person_group_xml_items is None:
             groups = []
             if self.elem_citation_nodes is not None:
-                for person_group in self.root_xml_node.nodes(['.//person-group']):
+                for person_group in self.person_group_nodes:
                     role = person_group.attrib.get('person-group-type', 'author')
                     authors = []
                     etal = None

--- a/src/scielo/bin/xml/modules/app/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/modules/app/validations/article_content_validations.py
@@ -908,8 +908,10 @@ class ArticleContentValidation(object):
             year = self.article.pub_date_year
         if year is None:
             year = datetime.now().isoformat()[0:4]
+        previous_refxml = None
         for ref_xml in self.article.references_xml:
-            r.append((ref_xml.reference, ref_validations.ReferenceContentValidation(ref_xml).evaluate(year)))
+            r.append((ref_xml.reference, ref_validations.ReferenceContentValidation(ref_xml, previous_refxml).evaluate(year)))
+            previous_refxml = ref_xml
         return r
 
     @property

--- a/src/scielo/bin/xml/modules/app/ws/institutions_db.py
+++ b/src/scielo/bin/xml/modules/app/ws/institutions_db.py
@@ -95,7 +95,7 @@ class InstitutionsDBManager(object):
 
     def similar_institutions(self, orgname, city, state, country_code, country_name):
         r = []
-
+        orgname = orgname.replace('"', '')
         similar_orgname_expr = ' OR '.join(['name LIKE ' + "'%" + word + "%'" for word in orgname.split(' ')])
         if len(similar_orgname_expr) > 0:
             similar_orgname_expr = '(' + similar_orgname_expr + ')'

--- a/src/scielo/bin/xml/modules/generics/dbm/dbm_sql.py
+++ b/src/scielo/bin/xml/modules/generics/dbm/dbm_sql.py
@@ -47,6 +47,7 @@ class SQL(object):
                     results.append(row)
             except Exception as e:
                 encoding.report_exception('query()', e, ('ERROR: query', expr))
+                encoding.debugging('query()', expr)
         conn.close()
         return results
 
@@ -68,5 +69,5 @@ class SQL(object):
         return expr
 
     def format_expr(self, labels, values, connector=' OR '):
-        expr = [label + '="' + encoding.encode(value) + '"' for label, value in zip(labels, values) if value is not None]
+        expr = [label + '="' + encoding.encode(value.replace('"', '')) + '"' for label, value in zip(labels, values) if value is not None]
         return connector.join(expr)


### PR DESCRIPTION
Validação de previous autor

Fixes #2597
corrige a expressão de busca para  resolver orgname que contém palavras entre aspas