### PR TITLE
[tk3017] Incluir validação de Publisher x Prefixes em validação de DOI

### DIFF
--- a/src/scielo/bin/xml/app_modules/generics/doi_validations.py
+++ b/src/scielo/bin/xml/app_modules/generics/doi_validations.py
@@ -53,8 +53,27 @@ class DOIValidator(object):
                 doi_prefix = self.ws_doi.journal_prefix(issn, article.pub_date_year)
                 if doi_prefix is not None:
                     valid_prefixes.append(doi_prefix)
+        print((valid_prefixes))
         if len(valid_prefixes) > 0 and prefix not in valid_prefixes:
             self.messages.append(('doi', validation_status.STATUS_FATAL_ERROR, _('{value} is an invalid value for {label}. ').format(value=prefix, label=_('doi prefix')) + _('{label} must starts with: {expected}. ').format(label='doi', expected=_(' or ').join(valid_prefixes))))
+        elif len(valid_prefixes) == 0:
+            issns = [article.e_issn, article.print_issn]
+            journal_provider, prefix_provider = self.ws_doi.journal_and_prefix(
+                prefix, issns)
+            if prefix_provider != journal_provider:
+                msgs = [
+                    article.doi,
+                    _('{value} is an invalid value for {label}. ').format(
+                            value=prefix,
+                            label=_('doi prefix')),
+                    _('"{}" belongs to {}. ').format(prefix, prefix_provider),
+                    _('DOI Publisher for {}: {}. ').format(
+                        article.journal_title, journal_provider)
+                ]
+                self.messages.append(
+                    ('doi',
+                     validation_status.STATUS_FATAL_ERROR,
+                     msgs))
 
     def _validate_journal_title(self, article, doi_data):
         if doi_data.journal_titles is not None:

--- a/src/scielo/bin/xml/app_modules/generics/ws/ws_doi.py
+++ b/src/scielo/bin/xml/app_modules/generics/ws/ws_doi.py
@@ -12,6 +12,8 @@ class DOIWebServicesRequester(object):
         self.doi_requested = {}
         self.doi_journal_prefixes = {}
         self.URL = 'https://api.crossref.org/works'
+        self.prefixes_endpoint_url = 'https://api.crossref.org/prefixes/{}'
+        self.journals_endpoint_url = 'https://api.crossref.org/journals/{}'
 
     def is_working(self):
         return self.ws_requester.is_valid_url(self.URL)
@@ -21,6 +23,18 @@ class DOIWebServicesRequester(object):
             year = datetime.now().year
         if issn is not None:
             return self.URL + '?filter=issn:{issn},from-pub-date:{year}'.format(issn=issn, year=year)
+
+    def journal_and_prefix(self, doi_prefix, issn_items):
+        for issn in issn_items:
+            json_results = self.ws_requester.json_result_request(
+                self.journals_endpoint_url.format(issn)) or {}
+            journal_provider_name = json_results.get('message', {}).get('publisher')
+            if journal_provider_name is not None:
+                break
+        json_results = self.ws_requester.json_result_request(
+            self.prefixes_endpoint_url.format(doi_prefix)) or {}
+        prefix_provider_name = json_results.get('message', {}).get('name')
+        return journal_provider_name, prefix_provider_name
 
     def article_doi_checker_url(self, doi):
         #https://api.crossref.org/works/10.1037/0003-066X.59.1.29


### PR DESCRIPTION
Para verificar se o prefixo do DOI está correto, atualmente é usado a seguinte consulta:
``https://api.crossref.org/works/?filter=issn:<ISSN>,from-pub-date:<PUBDATE>``

No entanto, quando o provedor é alterado durante um período, esta consulta não resolve. EXEMPLO:

Em 2018, o provedor é GN1.
https://api.crossref.org/works/?filter=issn:0103-4014,from-pub-date:2018
<img width="265" alt="captura de tela 2018-12-05 as 17 07 28" src="https://user-images.githubusercontent.com/505143/49537482-44fa7f80-f8b0-11e8-91bc-ec3725dc07de.png">

Em 2017, ainda era SciELO
https://api.crossref.org/works/?filter=issn:0103-4014,from-pub-date:2017
<img width="501" alt="captura de tela 2018-12-05 as 17 08 40" src="https://user-images.githubusercontent.com/505143/49537570-6eb3a680-f8b0-11e8-9379-f467d5a17cb4.png">

Sendo assim, foi incluído mais um tipo de validação
https://api.crossref.org/journals/0103-4014
<img width="392" alt="captura de tela 2018-12-05 as 17 01 43" src="https://user-images.githubusercontent.com/505143/49537239-9fdfa700-f8af-11e8-99f9-34c117c3f027.png">

https://api.crossref.org/prefixes/10.1590
<img width="501" alt="captura de tela 2018-12-05 as 17 03 21" src="https://user-images.githubusercontent.com/505143/49537276-b38b0d80-f8af-11e8-8be8-3ee849c945e5.png">


Fixes #3017 
tk3017