### PR TITLE
Exportar pacote para Kernel Gate

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/config/config.py
+++ b/src/scielo/bin/xml/app_modules/app/config/config.py
@@ -80,6 +80,13 @@ class Configuration(object):
         return path
 
     @property
+    def kernel_gate(self):
+        return {key[3:].lower(): self._data.get(key)
+                for key in self._data.keys()
+                if key.startswith("KG_")
+                }
+
+    @property
     def remote_web_app_path(self):
         return self._data.get('REMOTE_WEB_APP_PATH')
 

--- a/src/scielo/bin/xml/app_modules/generics/exporter.py
+++ b/src/scielo/bin/xml/app_modules/generics/exporter.py
@@ -1,0 +1,77 @@
+import zipfile
+import os
+import shutil
+import logging
+import tempfile
+from ftplib import FTP, all_errors
+
+
+class Exporter(object):
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def ftp_config(self):
+        try:
+            server = self._data["server"]
+            user = self._data["user"]
+            password = self._data["password"]
+            remote_path = self._data.get("remote_path")
+        except KeyError:
+            raise KeyError("Exporter: Configuration failure")
+        else:
+            return server, user, password, remote_path
+
+    def export(self, files_path, zip_filename):
+        zip_file_path = self.zip(files_path, zip_filename)
+        if zip_file_path:
+            self.export_by_ftp(zip_file_path)
+            try:
+                os.unlink(zip_file_path)
+                shutil.rmtree(os.path.dirname(zip_file_path))
+            except OSError:
+                logging.info(
+                    "Exporter: Unable to delete temp: %s" % zip_file_path)
+
+    def zip(self, files_path, zip_filename):
+        try:
+            dest_path = tempfile.mkdtemp()
+        except IOError:
+            logging.info("Exporter: Unable to create temp dir")
+        else:
+            zip_file_path = os.path.join(dest_path, zip_filename)
+            try:
+                with zipfile.ZipFile(zip_file_path, 'w') as zipf:
+                    for item in os.listdir(files_path):
+                        file_path = os.path.join(files_path, item)
+                        zipf.write(file_path, arcname=item)
+            except IOError:
+                logging.info(
+                    "Exporter: Unable to create zip: %s" % zip_filename
+                )
+            else:
+                return zip_file_path
+
+    def export_by_ftp(self, local_file_path):
+        try:
+            config = self.ftp_config
+        except KeyError:
+            logging.info("Export: Invalid configuration")
+        else:
+            server, user, password, remote_path = config
+            try:
+                with FTP(server, timeout=60) as ftp:
+                    ftp.login(user, password)
+                    if remote_path:
+                        ftp.cwd(remote_path)
+                    remote_name = os.path.basename(local_file_path)
+                    with open(local_file_path, 'rb') as f:
+                        try:
+                            ftp.storbinary('STOR {}'.format(remote_name), f)
+                        except all_errors:
+                            logging.info(
+                                'FTP: Unable to send %s to %s' %
+                                (local_file_path, remote_name), exc_info=True)
+            except all_errors:
+                logging.info("Unable to transfer: %s" % local_file_path)

--- a/src/scielo/bin/xml/tests/test_exporter.py
+++ b/src/scielo/bin/xml/tests/test_exporter.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, Mock, ANY
+
+import tempfile
+import os
+import shutil
+
+
+from app_modules.generics.exporter import Exporter
+
+
+class TestExporter(unittest.TestCase):
+
+    def setUp(self):
+        self.files_path = tempfile.mkdtemp()
+        for item in "abc":
+            with open(os.path.join(self.files_path, item), "w") as fp:
+                fp.write(item)
+
+    @patch('app_modules.generics.exporter.FTP')
+    def test_export(self, MockFTP):
+        data = dict(
+            (
+                ("server", "server"),
+                ("password", "password"),
+                ("remote_path", "remote_path"),
+                ("user", "user"),
+            )
+        )
+        MockFTP.return_value = Mock(__enter__=MockFTP, __exit__=Mock())
+        mock_ftp = MockFTP()
+
+        exporter = Exporter(data)
+        exporter.export(self.files_path, "xxx.zip")
+
+        mock_ftp.login.assert_called_with("user", "password")
+        mock_ftp.cwd.assert_called_with('remote_path')
+        mock_ftp.storbinary.assert_called_with('STOR xxx.zip', ANY)
+
+    def test_export_raises_configuration_error(self):
+        data = dict(
+            (
+                ("server", "server"),
+                ("password", "password"),
+                ("remote_path", "remote_path"),
+            )
+        )
+        exporter = Exporter(data)
+        with self.assertRaises(KeyError) as exc_info:
+            exporter.ftp_config
+        self.assertEqual(
+            str(exc_info.exception), "'Exporter: Configuration failure'")
+
+    def tearDown(self):
+        shutil.rmtree(self.files_path)


### PR DESCRIPTION
#### O que esse PR faz?
Após passar o pacote de documentos passar pela conversão à base ISIS, o XML Converter gera um arquivo compactado cujo nome corresponde à sua representação na scilista, por exemplo: abc v10n2 ficaria abc_v10n12.zip e o transfere para um ftp configurado para ficar disponível para o Kernel Gate.

#### Onde a revisão poderia começar?
src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py:120
src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py:373
src/scielo/bin/xml/app_modules/generics/exporter.py
src/scielo/bin/xml/tests/test_exporter.py


#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_exporter`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#3121 

### Referências
N/A
