### PR TITLE
Corrige atributo de elemento para identificador do SciELO

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/data/scielo_id_manager.py
+++ b/src/scielo/bin/xml/app_modules/app/data/scielo_id_manager.py
@@ -27,7 +27,7 @@ def add_scielo_id(received, registered, file_path):
     if node is not None:
         article_id = ET.Element("article-id")
         article_id.set("specific-use", "scielo")
-        article_id.set("pub-type-id", "publisher-id")
+        article_id.set("pub-id-type", "publisher-id")
         article_id.text = received.registered_scielo_id
         node.insert(0, article_id)
         new_content = ET.tostring(xml.find(".")).decode("utf-8")


### PR DESCRIPTION
Este commit corrige um erro de digitação no nome do atributo do elemento
`<article-id>` responsável por armazenar o identificador único do SciELO
para o documento.