### PR TITLE
Adiciona docker para o XC.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:18.04
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    gcc \
+    git \
+    libpq-dev \
+    make \
+    python-pip \
+    python2.7 \
+    python2.7-dev \
+    ssh \
+    lib32z1 \
+    lib32z1-dev \
+    && apt-get autoremove \
+    && apt-get clean
+
+COPY ./requirements.txt /app/requirements.txt
+
+RUN pip --no-cache-dir install -r /app/requirements.txt
+RUN chown -R nobody:nogroup /app
+
+RUN wget https://github.com/bireme/cisis/releases/download/32bits-5.7e-1660/cisis-32bits-5.7e-1660.tar.gz
+
+RUN mkdir cisis
+
+RUN tar vxzf cisis-32bits-5.7e-1660.tar.gz -C cisis \
+    && chmod +x cisis \
+    && chown nobody cisis \
+    && mv cisis/* /bin
+
+USER nobody
+
+WORKDIR /app
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+packtools==2.5.5
+Pillow==6.2.0


### PR DESCRIPTION
### Descrição da tarefa:

Adiciona a capacidade de utilizar docker, com **cisis** instalado no bash do container.

O **cisis** ficou disponível no Shell, portanto é possível utilizar somente _mx_ _id2i_ e etc, diretamente no terminal

## Para utilizar o container:

- Necessário construir uma imagem: 
```docker build -t xc_image .``` Repare que o nome da imagem é xc_image
- É necessário rodar o container em foreground utilizando a opção **-t** que cria um pseudo terminal (tty):
 ```docker run -t -d --name xc xc_image```
- Nesse ponto é possível acessar o container com o seguinte comando:
```docker exec -ti xc sh```

### Screenshots ou vídeos

<img width="1440" alt="Screenshot 2019-10-17 16 01 17" src="https://user-images.githubusercontent.com/373745/67039273-60046580-f0f7-11e9-85c1-b7b5cf9b3f28.png">
