### PR TITLE
[xpm] Exigir pelo menos 1 contrib-id do tipo orcid

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/app_modules/app/validations/article_data_reports.py
@@ -55,19 +55,16 @@ def format_author(author):
 
 
 def display_author(author):
-    text = ''
+    texts = []
     if isinstance(author, PersonAuthor):
-        if author.surname is not None:
-            text += html_reports.tag('span', author.surname, 'surname')
-
-        if author.suffix is not None:
-            text += ' ' + html_reports.tag('span', author.suffix, 'suffix')
-
-        if author.fname is not None:
-            text += ', ' + html_reports.tag('span', author.fname, 'name')
+        labels = ('surname', 'suffix', 'name', 'orcid')
+        values = (author.surname, author.suffix, author.fname, author.contrib_id.get("orcid", ""))
+        for label, value in zip(labels, values):
+            if value:
+                texts.append(html_reports.tag('span', value, label))
     else:
-        text += html_reports.tag('span', author.collab, 'collab')
-    return text
+        texts.append(html_reports.tag('span', author.collab, 'collab'))
+    return ", ".join([text for text in texts if text])
 
 
 def display_authors(authors_list, sep):

--- a/src/scielo/bin/xml/app_modules/app/validations/orcid.py
+++ b/src/scielo/bin/xml/app_modules/app/validations/orcid.py
@@ -1,0 +1,74 @@
+# coding = utf-8
+from ... import _
+from ...generics.reports import validation_status
+from ...generics.reports import html_reports
+
+
+class ORCIDValidator:
+
+    def __init__(self, ws_requester):
+        self.ORCID_MAIN_URL = 'https://orcid.org/'
+        self._is_available_orcid_website = None
+        self.ws_requester = ws_requester
+
+    @property
+    def is_available_orcid_website(self):
+        if not self.ws_requester:
+            return False
+        if self._is_available_orcid_website is None:
+            self._is_available_orcid_website = self.ws_requester.is_valid_url(
+                self.ORCID_MAIN_URL)
+        return self._is_available_orcid_website
+
+    def validate_contrib_names(self, contrib_names):
+        with_orcid = {}
+        msgs = []
+        for contrib_name in contrib_names:
+            orcid = contrib_name.contrib_id.get('orcid')
+            if orcid is None:
+                continue
+            error_msg = self._is_duplicated(with_orcid, orcid, contrib_name)
+            if error_msg:
+                msgs.append(error_msg)
+            else:
+                error_msg = self._is_valid_orcid(orcid, contrib_name)
+                if error_msg:
+                    msgs.append(error_msg)
+
+        if len(with_orcid) == 0:
+            error_msg = (
+                'contrib-id',
+                validation_status.STATUS_FATAL_ERROR,
+                _("It is required at least one {label}. ".format(
+                    label="orcid"))
+            )
+            msgs.append(error_msg)
+        return msgs
+
+    def _is_duplicated(self, with_orcid, orcid, contrib_name):
+        contrib = with_orcid.get(orcid)
+        if not contrib:
+            with_orcid[orcid] = contrib_name.fullname
+        if contrib and contrib != contrib_name.fullname:
+            return (
+                'contrib-id',
+                validation_status.STATUS_BLOCKING_ERROR,
+                _('"{}" and "{}"" can not have the same ORCID: {}').format(
+                   contrib_name.fullname, contrib, orcid
+                )
+            )
+
+    def _is_valid_orcid(self, orcid, contrib_name):
+        contrib_orcid_url = '{}{}'.format(self.ORCID_MAIN_URL, orcid)
+        if self.is_available_orcid_website:
+            if not self.ws_requester.is_valid_url(contrib_orcid_url):
+                return (
+                    'contrib-id',
+                    validation_status.STATUS_FATAL_ERROR,
+                    _('{value} is an invalid value for {label}. ').format(
+                        value=orcid, label='ORCID'))
+        return ('contrib-id',
+                validation_status.STATUS_WARNING,
+                _('Unable to check if {} belongs to {}. ').format(
+                    html_reports.link(contrib_orcid_url, orcid),
+                    contrib_name.fullname))


### PR DESCRIPTION
#### O que esse PR faz?

- Indicar FATAL_ERROR quando não existe nenhum ORCID no documento.
- Refatora a validação do contrib-id do tipo orcid
- Apresenta o ORCID no relatório

#### Onde a revisão poderia começar?
- Refatora a validação do contrib-id do tipo orcid
    - src/scielo/bin/xml/app_modules/app/validations/orcid.py
    - src/scielo/bin/xml/app_modules/app/validations/article_content_validations.py: L:568
- Indicar FATAL_ERROR quando não existe nenhum ORCID no documento.
   - src/scielo/bin/xml/app_modules/app/validations/orcid.py: L:38
- Apresenta o ORCID no relatório
   - src/scielo/bin/xml/app_modules/app/validations/article_data_reports.py: L:57

#### Como este poderia ser testado manualmente?
`python xml_package_maker.py ~/Downloads/0104-5970-hcsm-26-03-0969.xml`

[0104-5970-hcsm-26-03-0969.xml.zip](https://github.com/scieloorg/PC-Programs/files/3806008/0104-5970-hcsm-26-03-0969.xml.zip)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
- Apresenta o ORCID no relatório

<img width="411" alt="Captura de Tela 2019-11-04 às 17 51 47" src="https://user-images.githubusercontent.com/505143/68157178-ee684c00-ff2b-11e9-8a49-6c7d767be8e3.png">

- Indica FATAL_ERROR quando não existe nenhum ORCID no documento.
<img width="801" alt="Captura de Tela 2019-11-04 às 17 53 59" src="https://user-images.githubusercontent.com/505143/68157287-1d7ebd80-ff2c-11e9-9d55-db13773c566f.png">

#### Quais são tickets relevantes?
#3142 

### Referências
n/a
