### PR TITLE
Corrige a obtenção do issn_id, bug do PR 3145

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
+++ b/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
@@ -122,7 +122,7 @@ class ArticlesConversion(object):
         scilista_items = [self.pkg.issue_data.acron_issue_label]
         if self.validations_reports.blocking_errors == 0 and (self.accepted_articles == len(self.pkg.articles) or len(self.articles_mergence.excluded_orders) > 0):
             self.error_messages = self.db.exclude_articles(self.articles_mergence.excluded_orders)
-            issn_id = self.registered_issue_data.issue_models.issn_id
+            issn_id = self.registered_issue_data.issue_models.issue.issn_id
             v36 = self.registered_issue_data.issue_models.record.get("36")
             kernel_document.add_article_id_to_received_documents(
                 issn_id, v36,


### PR DESCRIPTION
#### O que esse PR faz?
Corrige bug do PR #3145, erro na obtenção do issn_id

#### Onde a revisão poderia começar?
src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
este erro foi identificado na dsteste, foi corrigido e testado lá
```shell
    scilista_items = conversion.convert(self.export_documents_package)
  File "/home/scielo/xc/app/xc_2019/xml/app_modules/app/pkg_processors/pkg_processors.py", line 125, in convert
    issn_id = self.registered_issue_data.issue_models.issn_id
AttributeError: 'IssueModels' object has no attribute 'issn_id'
```

### Screenshots
n/a

#### Quais são tickets relevantes?
PR #3145

### Referências
n/a
