### PR TITLE
Corrige a geração das datas para o XML do PubMed

### DIFF
--- a/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
@@ -399,6 +399,9 @@
 			<xsl:when test=".//front//pub-date[@date-type='pub']">
 				<xsl:apply-templates select=".//front//pub-date[@date-type='pub']"/>
 			</xsl:when>
+			<xsl:when test=".//front//pub-date[@pub-type='epub']">
+				<xsl:apply-templates select=".//front//pub-date[@pub-type='epub']"/>
+			</xsl:when>
 			<xsl:when test=".//front//pub-date[@pub-type='collection']">
 				<xsl:apply-templates select=".//front//pub-date[@pub-type='collection']"/>
 			</xsl:when>
@@ -407,9 +410,6 @@
 			</xsl:when>
 			<xsl:when test=".//front//pub-date[@pub-type='epub-ppub']">
 				<xsl:apply-templates select=".//front//pub-date[@pub-type='epub-ppub']"/>
-			</xsl:when>
-			<xsl:when test=".//front//pub-date[@pub-type='epub']">
-				<xsl:apply-templates select=".//front//pub-date[@pub-type='epub']"/>
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:apply-templates select=".//front//pub-date[1]"/>

--- a/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
@@ -137,9 +137,8 @@
 				<History>
 					<xsl:apply-templates select=".//article-meta//history/*"/>
 					<xsl:if test="count(.//article-meta//pub-date)&gt;1">
-						<xsl:if test=".//article-meta//pub-date[@pub-type='epub' and day]">
-							<xsl:apply-templates select=".//article-meta//pub-date[@pub-type='epub' and day]" mode="history"/>
-						</xsl:if>
+						<xsl:apply-templates select=".//article-meta//pub-date[@pub-type='epub' and day]" mode="history"/>
+						<xsl:apply-templates select=".//article-meta//pub-date[@date-type='pub' and day]" mode="history"/>
 					</xsl:if>
 				</History>
 			</xsl:if>
@@ -397,6 +396,9 @@
 	</xsl:template>
 	<xsl:template match="*" mode="scielo-xml-publishing_dateiso">
 		<xsl:choose>
+			<xsl:when test=".//front//pub-date[@date-type='pub']">
+				<xsl:apply-templates select=".//front//pub-date[@date-type='pub']"/>
+			</xsl:when>
 			<xsl:when test=".//front//pub-date[@pub-type='collection']">
 				<xsl:apply-templates select=".//front//pub-date[@pub-type='collection']"/>
 			</xsl:when>
@@ -417,15 +419,10 @@
 	<xsl:template match="@date-type[.='pub']">
 		<xsl:variable name="issueid"><xsl:value-of select="normalize-space(translate(concat(../../volume,../../issue),'0',' '))"/></xsl:variable>
 		<xsl:choose>
-			<xsl:when test="../@publication-format='electronic'">
-				<xsl:choose>
-					<xsl:when test="$issueid=''">aheadofprint</xsl:when>
-					<xsl:when test="$issueid!=''">epublish</xsl:when>
-					<xsl:when test="../pub-date/day">aheadofprint</xsl:when>
-				</xsl:choose>
-			</xsl:when>
-			<xsl:otherwise>ppublish</xsl:otherwise>			
-		</xsl:choose>
+			<xsl:when test="$issueid=''">aheadofprint</xsl:when>
+			<xsl:when test="$issueid!=''">epublish</xsl:when>
+			<xsl:when test="../pub-date/day">aheadofprint</xsl:when>
+		</xsl:choose>		
 	</xsl:template>
 	<xsl:template match="pub-date/@pub-type">
 		<xsl:variable name="issueid"><xsl:value-of select="normalize-space(translate(concat(../../volume,../../issue),'0',' '))"/></xsl:variable>
@@ -434,7 +431,7 @@
 			<xsl:when test=".='epub' and $issueid!=''">epublish</xsl:when>
 			<xsl:when test=".='epub' and ../day">aheadofprint</xsl:when>
 			<xsl:when test=".='ppub'">ppublish</xsl:when>
-			<xsl:when test=".='epub-ppub'">ppublish</xsl:when>
+			<xsl:when test=".='epub-ppub'">epublish</xsl:when>
 			<xsl:when test=".='collection'">ppublish</xsl:when>
 			<xsl:otherwise>
 				<xsl:value-of select="."/>
@@ -470,10 +467,8 @@
 	</xsl:template>
 	<xsl:template match="pub-date" mode="history">
 		<PubDate>
-			<xsl:attribute name="PubStatus">aheadofprint</xsl:attribute>
+			<xsl:attribute name="PubStatus">ecollection</xsl:attribute>
 			<xsl:apply-templates select="year"/>
-			<xsl:apply-templates select="month|season"/>
-			<xsl:apply-templates select="day"/>
 		</PubDate>
 	</xsl:template>
 	<xsl:template match="month|season">

--- a/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl
@@ -133,19 +133,23 @@
 			</ArticleIdList>
 			<xsl:if test=".//front//history">
 				<xsl:variable name="issueid"><xsl:value-of select="normalize-space(translate(concat(.//article-meta/volume,.//article-meta/issue),'0',' '))"/></xsl:variable>
-				
+					
 				<History>
 					<xsl:apply-templates select=".//article-meta//history/*"/>
+
 					<xsl:if test="count(.//article-meta//pub-date)&gt;1">
 						<xsl:apply-templates select=".//article-meta//pub-date[@pub-type='epub' and day]" mode="history"/>
-						<xsl:apply-templates select=".//article-meta//pub-date[@date-type='pub' and day]" mode="history"/>
-					</xsl:if>
+						<xsl:if test="not(.//article-meta//pub-date[@date-type='collection']/season or .//article-meta//pub-date[@date-type='collection']/month) and $issueid!=''">
+							<xsl:apply-templates select=".//article-meta//pub-date[@date-type='pub' and day]" mode="history"/>
+						</xsl:if>
+					</xsl:if>			
 				</History>
 			</xsl:if>
 			<xsl:apply-templates select="." mode="scielo-xml-abstract"/>
 			<xsl:apply-templates select="." mode="scielo-xml-objects"/>
 		</Article>
 	</xsl:template>
+	
 	<xsl:template match="related-article[@related-article-type='corrected-article' or @related-article-type='retracted-article']" mode="scielo-xml-object">
 		<xsl:param name="article_type"/>
 		<ObjectList>
@@ -396,14 +400,23 @@
 	</xsl:template>
 	<xsl:template match="*" mode="scielo-xml-publishing_dateiso">
 		<xsl:choose>
-			<xsl:when test=".//front//pub-date[@date-type='pub']">
-				<xsl:apply-templates select=".//front//pub-date[@date-type='pub']"/>
+			<xsl:when test=".//front//pub-date[@date-type='collection']/month">
+				<xsl:apply-templates select=".//front//pub-date[@date-type='collection']"/>
+			</xsl:when>
+			<xsl:when test=".//front//pub-date[@date-type='collection']/season">
+				<xsl:apply-templates select=".//front//pub-date[@date-type='collection']"/>
+			</xsl:when>
+			<xsl:when test=".//front//pub-date[@date-type='epub']">
+				<xsl:apply-templates select=".//front//pub-date[@date-type='epub']"/>
+			</xsl:when>
+			<xsl:when test=".//front//pub-date[@pub-type='collection']/month">
+				<xsl:apply-templates select=".//front//pub-date[@pub-type='collection']"/>
+			</xsl:when>
+			<xsl:when test=".//front//pub-date[@pub-type='collection']/season">
+				<xsl:apply-templates select=".//front//pub-date[@pub-type='collection']"/>
 			</xsl:when>
 			<xsl:when test=".//front//pub-date[@pub-type='epub']">
 				<xsl:apply-templates select=".//front//pub-date[@pub-type='epub']"/>
-			</xsl:when>
-			<xsl:when test=".//front//pub-date[@pub-type='collection']">
-				<xsl:apply-templates select=".//front//pub-date[@pub-type='collection']"/>
 			</xsl:when>
 			<xsl:when test=".//front//pub-date[@pub-type='ppub']">
 				<xsl:apply-templates select=".//front//pub-date[@pub-type='ppub']"/>
@@ -421,21 +434,14 @@
 		<xsl:choose>
 			<xsl:when test="$issueid=''">aheadofprint</xsl:when>
 			<xsl:when test="$issueid!=''">epublish</xsl:when>
-			<xsl:when test="../pub-date/day">aheadofprint</xsl:when>
-		</xsl:choose>		
+		</xsl:choose>	
 	</xsl:template>
+	<xsl:template match="@date-type[.='collection']">ppublish</xsl:template>
 	<xsl:template match="pub-date/@pub-type">
-		<xsl:variable name="issueid"><xsl:value-of select="normalize-space(translate(concat(../../volume,../../issue),'0',' '))"/></xsl:variable>
 		<xsl:choose>
-			<xsl:when test=".='epub' and $issueid=''">aheadofprint</xsl:when>
-			<xsl:when test=".='epub' and $issueid!=''">epublish</xsl:when>
-			<xsl:when test=".='epub' and ../day">aheadofprint</xsl:when>
-			<xsl:when test=".='ppub'">ppublish</xsl:when>
-			<xsl:when test=".='epub-ppub'">epublish</xsl:when>
+			<xsl:when test=".='epub'">epublish</xsl:when>
 			<xsl:when test=".='collection'">ppublish</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="."/>
-			</xsl:otherwise>
+			<xsl:otherwise>ppublish</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
 	


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a geração das datas para o XML do PubMed, considerando as novas regras da versão SPS 1.8 e 1.9
http://docs.scielo.org/projects/scielo-publishing-schema

Para publicação contínua, preencher com "pub" ou "epub" e em `<History>` a data `collection`:
```xml
<PubDate PubStatus="epublish">
	<Year>2019</Year>
	<Month>09</Month>
	<Day>23</Day>
</PubDate>
```

```xml
<History>
        <PubDate PubStatus="ecollection">
	       <Year>2019</Year>
	</PubDate>
</History>
```
vem da data "collection"

Para publicação ahead of print, preencher com a data epub ou pub e não colocar nada em `<History/>`:
```xml
<PubDate PubStatus="aheadofprint">
            <Year>2019</Year>
            <Month>11</Month>
            <Day>04</Day>
</PubDate>
```

Para fascículo regular, preencher com a data `collection` e não colocar nada em `<History/>`
```xml
<PubDate PubStatus="ppublish">
	<Year>2019</Year>
	<Month>11</Month>			
</PubDate>
```

#### Onde a revisão poderia começar?
src/scielo/bin/pmc/v3.0/xsl/xml2pubmed/xml2pubmed.xsl

#### Como este poderia ser testado manualmente?
Testados pela equipe de produção

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3132

### Referências
http://docs.scielo.org/projects/scielo-publishing-schema
