### PR TITLE
Altera as várias ferramentas para não lidar com os nomes de afiliações normalizados

### DIFF
--- a/src/scielo/bin/markup/app_core/tree.txt
+++ b/src/scielo/bin/markup/app_core/tree.txt
@@ -904,7 +904,7 @@ glossary;#TRUE#;#FALSE#
 hist;#TRUE#;#FALSE#
 *kwdgrp;#FALSE#;#TRUE#
 kwdgrp;#FALSE#;#TRUE#
-normaff;#TRUE#;#TRUE#
+aff;#TRUE#;#TRUE#
 onbehalf;#FALSE#;#FALSE#
 related;#FALSE#;#TRUE#
 subdoc;#FALSE#;#TRUE#
@@ -968,7 +968,7 @@ glossary;#FALSE#;#FALSE#
 hist;#FALSE#;#FALSE#
 *kwdgrp;#FALSE#;#TRUE#
 kwdgrp;#FALSE#;#TRUE#
-normaff;#TRUE#;#TRUE#
+aff;#TRUE#;#TRUE#
 onbehalf;#FALSE#;#FALSE#
 related;#FALSE#;#TRUE#
 subdoc;#FALSE#;#TRUE#

--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -679,9 +679,15 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				<xsl:if test="count(normaff)=1">
 					<xsl:apply-templates select="normaff"/>
 				</xsl:if>
+				<xsl:if test="count(aff)=1">
+					<xsl:apply-templates select="aff"/>
+				</xsl:if>
 			</contrib-group>
 			<xsl:if test="count(normaff)&gt;1">
 				<xsl:apply-templates select="normaff"/>
+			</xsl:if>
+			<xsl:if test="count(aff)&gt;1">
+				<xsl:apply-templates select="aff"/>
 			</xsl:if>
 		</xsl:if>
 	</xsl:template>
@@ -722,9 +728,6 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 	
 	<xsl:template match="doc | subdoc | docresp" mode="front-contrib-group">
 		<xsl:choose>
-			<xsl:when test=".//aff">
-				<aff content-type="USE normaff instead of aff"></aff>
-			</xsl:when>
 			<xsl:when test="author or corpauth">
 				<contrib-group>
 					<xsl:apply-templates select="author|corpauth" mode="front-contrib"/>
@@ -733,6 +736,9 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 							<xsl:value-of select="onbehalf"/>
 						</on-behalf-of>
 					</xsl:if>
+					<xsl:if test="count(aff)=1">
+						<xsl:apply-templates select="aff"/>
+					</xsl:if>
 					<xsl:if test="count(normaff)=1">
 						<xsl:apply-templates select="normaff"/>
 					</xsl:if>
@@ -740,6 +746,9 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 						<xsl:apply-templates select="afftrans"/>
 					</xsl:if>
 				</contrib-group>
+				<xsl:if test="count(aff)&gt;1">
+					<xsl:apply-templates select="aff"/>
+				</xsl:if>
 				<xsl:if test="count(normaff)&gt;1">
 					<xsl:apply-templates select="normaff"/>
 				</xsl:if>
@@ -753,9 +762,15 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 					<xsl:if test="count(normaff)=1">
 						<xsl:apply-templates select="normaff"/>
 					</xsl:if>
+					<xsl:if test="count(aff)=1">
+						<xsl:apply-templates select="aff"/>
+					</xsl:if>
 				</contrib-group>
 				<xsl:if test="count(normaff)&gt;1">
 					<xsl:apply-templates select="normaff"/>
+				</xsl:if>
+				<xsl:if test="count(aff)&gt;1">
+					<xsl:apply-templates select="aff"/>
 				</xsl:if>
 			</xsl:when>
 		</xsl:choose>
@@ -1072,9 +1087,6 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 		<institution content-type="original"><xsl:apply-templates select="*[name()!='label']|text()" mode="original"/></institution>
 		<xsl:choose>
 			<xsl:when test="@norgname">
-				<xsl:if test="@norgname!='Not normalized'">
-					<institution content-type="normalized"><xsl:value-of select="@norgname"/></institution>	
-				</xsl:if>
 				<xsl:apply-templates select="*[contains(name(),'org')]"/>
 			</xsl:when>				
 			<xsl:when test="@orgname">

--- a/src/scielo/bin/xml/app_modules/app/db/xc_models.py
+++ b/src/scielo/bin/xml/app_modules/app/db/xc_models.py
@@ -301,7 +301,7 @@ class ArticleRecords(object):
         self._metadata['14']['e'] = self.article.elocation_id
 
         self._metadata['70'] = format_affiliations(self.article.affiliations)
-        self._metadata['240'] = format_normalized_affiliations(self.article.normalized_affiliations)
+        #self._metadata['240'] = format_normalized_affiliations(self.article.normalized_affiliations)
         #CT^uhttp://www.clinicaltrials.gov/ct2/show/NCT01358773^aNCT01358773
         self._metadata['770'] = {'u': self.article.clinical_trial_url}
         self._metadata['72'] = str(0 if self.article.total_of_references is None else self.article.total_of_references)

--- a/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
+++ b/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
@@ -406,15 +406,7 @@ class PkgProcessor(object):
     def evaluate_package(self, pkg):
         registered_issue_data = registered.RegisteredIssue()
         self.registered_issues_manager.get_registered_issue_data(pkg.issue_data, registered_issue_data)
-        for xml_name in sorted(pkg.articles.keys()):
-            a = pkg.articles[xml_name]
-            if a is not None:
-                institutions_results = {}
-                for aff_xml in a.affiliations:
-                    if aff_xml is not None:
-                        institutions_results[aff_xml.id] = self.aff_normalizer.query_institutions(aff_xml)
-                pkg.articles[xml_name].institutions_query_results = institutions_results
-                pkg.articles[xml_name].normalized_affiliations = {aff_id: info[0] for aff_id, info in institutions_results.items()}
+        
         pkg_validations = self.validate_pkg_articles(pkg, registered_issue_data)
 
         articles_mergence = self.validate_merged_articles(pkg, registered_issue_data)


### PR DESCRIPTION
#### O que esse PR faz?
- Troca a tag normaff por aff no Markup
- Gera a tag aff sem a `<institution content-type="normalized"/>`
- Não armazena mais os dados de afiliação normalizada na base de dados (campo v240)

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?

- Usando o programa de Marcação
- Gerando o pacote
- Usando o XML Converter


#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
...

#### Quais são tickets relevantes?
#3156

### Referências
n/a
