### PR TITLE
Ajustes em new_index.rst

### DIFF
--- a/docs/source/new_index.rst
+++ b/docs/source/new_index.rst
@@ -1,58 +1,8 @@
 
-SciELO PC Programs
-==================
+SciELO PC Programs (Versão em desenvolvimento)
+==============================================
 
-Guia para usuários Produtores de marcação XML
----------------------------------------------
-
-.. toctree::
-    :maxdepth: 1
-
-    pt_installation_requirements.rst
-    pt_installation_download.rst
-    pt_installation_configure.rst
-
-    markup.rst
-    v94_pt.rst
-    markup_tags.rst
-    markup_reports.rst
-
-    xml_package_maker.rst
-
-    pt_how_to_generate_xml-prepara.rst
-	pt_how_to_generate_xml-markup.rst
-	pt_how_to_generate_xml-results.rst
-	
-    pt_how_to_validate_xml_package.rst
- 
-    pt_faq-scielo-xml.rst
-
-    support.rst
-
-
-Guia para usuários Coordenadores de Coleção XML 
-
-.. toctree::
-    :maxdepth: 1
-
-    pt_installation_requirements.rst
-    pt_installation_download.rst
-    pt_installation_configure.rst
-
-    xml_package_maker.rst
-    xml_converter.rst
-
-    pt_how_to_generate_xml-prepara.rst
-	pt_how_to_generate_xml-markup.rst
-	pt_how_to_generate_xml-results.rst
-	pt_how_to_validate_xml_package.rst
-
-    pt_faq-scielo-xml.rst
-
-    support.rst
-
-
-Guia para usuários Produtores de marcação HTML 
+Guias para usuários Produtores de marcação XML
 ----------------------------------------------
 
 .. toctree::
@@ -63,16 +13,23 @@ Guia para usuários Produtores de marcação HTML
     pt_installation_configure.rst
 
     markup.rst
-    parser.rst
-    automata.rst
+    xml_package_maker.rst
 
-    pt_how_to_generate_sgml.rst
-    
+    pt_how_to_generate_xml-prepara.rst
+    pt_how_to_generate_xml-markup.rst
+    markup_tags.rst
+    v94_pt.rst
+
+    pt_how_to_generate_xml-results.rst    
+    pt_how_to_validate_xml_package.rst
+ 
+    pt_faq-scielo-xml.rst
+
     support.rst
 
 
-Guia para usuários Coordenadores de Coleção somente HTML 
---------------------------------------------------------
+Guias para usuários Coordenadores de Coleção XML
+------------------------------------------------
 
 .. toctree::
     :maxdepth: 1
@@ -80,27 +37,65 @@ Guia para usuários Coordenadores de Coleção somente HTML
     pt_installation_requirements.rst
     pt_installation_download.rst
     pt_installation_configure.rst
-	
+
+    xml_converter.rst
+
+    pt_faq-scielo-xml.rst
+
+    pt_how_to_update_local_site.rst
+
+    support.rst
+
+
+Guias para usuários Produtores de marcação HTML 
+-----------------------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    pt_installation_requirements.rst
+    pt_installation_download.rst
+    pt_installation_configure.rst
+
+    markup.rst
+    automata.rst
     parser.rst
-	converter.rst
 
     pt_how_to_generate_sgml.rst
-	pt_how_to_update_local_site.rst
+    
+    support.rst
 
-	automata.rst
+
+Guias para usuários Coordenadores de Coleção HTML 
+-------------------------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    pt_installation_requirements.rst
+    pt_installation_download.rst
+    pt_installation_configure.rst
+    
+    converter.rst
+
+    pt_how_to_generate_sgml.rst
+    pt_how_to_update_local_site.rst
+
+    automata.rst
 
     support.rst
     
 
-Guias Gerais para Coordenadores de Coleção
+Outros guias para Coordenadores de Coleção
 ------------------------------------------
 
 .. toctree::
     :maxdepth: 1
 
-	codemanager.rst
-	concepts.rst
+    codemanager.rst
     xml_exporter.rst
+
+    concepts.rst
 
 
 Guias Coordenadores de Coleção - Title Manager
@@ -113,7 +108,7 @@ Guias Coordenadores de Coleção - Title Manager
     titlemanager_title.rst
     titlemanager_section.rst
     titlemanager_issue.rst
-	issue_and_section_databases.rst
+    issue_and_section_databases.rst
 
 
 Anexos
@@ -122,6 +117,7 @@ Anexos
 .. toctree::
     :maxdepth: 1
 
-	code_databse.rst
+    code_databse.rst
     newcode_database.rst
-	es_procedure_press_release.rst
+    es_procedure_press_release.rst
+


### PR DESCRIPTION
#### O que esse PR faz?
Cria um arquivo new_index.rst para agrupar a documentação de acordo com os perfis de usuários.
É para dar início à revisão dos manuais. 

#### Onde a revisão poderia começar?
docs/source/new_index.rst

#### Como este poderia ser testado manualmente?
Acessando http://docs.scielo.org/projects/scielo-pc-programs/en/latest/new_index.html

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
