### PR TITLE
Cria um gerenciador de PID da versão 3 baseado no PID da versão 2

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/config/config.py
+++ b/src/scielo/bin/xml/app_modules/app/config/config.py
@@ -95,6 +95,12 @@ class Configuration(object):
         return self._data.get('PROC_SERIAL_PATH', self._data.get('Serial Directory'))
 
     @property
+    def pid_manager_info(self):
+        return self._data.get(
+            'PID_MANAGER',
+            os.path.join(self.serial_path, "pid_manager.db"))
+
+    @property
     def issue_db(self):
         return self._data.get('SOURCE_ISSUE_DB', self._data.get('Issue Database'))
 

--- a/src/scielo/bin/xml/app_modules/app/data/kernel_document.py
+++ b/src/scielo/bin/xml/app_modules/app/data/kernel_document.py
@@ -1,33 +1,60 @@
 from ...generics import fs_utils
 from . import scielo_id_gen
+
 import xml.etree.ElementTree as ET
 
 
 def add_article_id_to_received_documents(
-    issn_id, year_and_order, received_docs, registered_docs, file_paths
-):
-    """Atualiza article-id (scielo-v2 e scielo-v3) dos documentos recebidos."""
+    pid_manager,
+    issn_id, year_and_order, received_docs, registered_docs, file_paths):
+    """
+    Atualiza article-id (scielo-v2 e scielo-v3) dos documentos recebidos.
+    pid_manager: instância de PIDVersionsManager para gerir pid da versão 3
+    issn_id: ISSN ID, chave para gerar o pid da versão 2
+    year_and_order: também faz parte do pid da versão 2
+    received_docs: pacote de documentos recebidos para processar
+    registered_docs: documentos já registrados na base isis (acron/volnum)
+    file_paths: arquivos do received_docs
+    """
     for name, received in received_docs.items():
         pid_v2 = received.get_scielo_pid("v2")
         pid_v3 = received.get_scielo_pid("v3")
         if pid_v2 and pid_v3:
+            """
+            TODO: validar o pid_v3 que está presente no pacote recebido
+            e / ou registrá-lo caso não esteja registrado
+            """
             continue
 
-        file_path = file_paths.get(name)
-        xml = ET.parse(file_path)
-        article_meta = xml.find(".//article-meta")
-        registered = registered_docs.get(name)
-
-        if not pid_v3:
-            received.registered_scielo_id = get_scielo_pid_v3(registered)
-            add_article_id(
-                article_meta, received.registered_scielo_id, "scielo-v3")
+        pid_and_specific_use_items = []
 
         if not pid_v2:
-            pid = get_scielo_pid_v2(issn_id, year_and_order, received.order)
-            add_article_id(article_meta, pid, "scielo-v2")
+            pid_v2 = get_scielo_pid_v2(issn_id, year_and_order, received.order)
+            pid_and_specific_use_items.append((pid_v2, "scielo-v2"))
 
-        save(file_path, xml)
+        if not pid_v3:
+            pid_v3_from_manager = None
+            registered = registered_docs.get(name)
+            if registered and registered.scielo_id:
+                pid_v3 = registered.scielo_id
+
+            if not pid_v3 and pid_manager:
+                pid_v3 = pid_manager.get_pid_v3(pid_v2)
+                pid_v3_from_manager = pid_v3
+
+            if not pid_v3:
+                pid_v3 = scielo_id_gen.generate_scielo_pid()
+
+            received.registered_scielo_id = pid_v3
+            if pid_v3_from_manager is None:
+                pid_manager.insert(pid_v2, pid_v3)
+
+            pid_and_specific_use_items.append((pid_v3, "scielo-v3"))
+
+        if pid_and_specific_use_items:
+            add_article_id_to_xml(
+                file_paths.get(name),
+                pid_and_specific_use_items)
 
 
 def get_scielo_pid_v2(issn_id, year_and_order, order_in_issue):
@@ -36,20 +63,15 @@ def get_scielo_pid_v2(issn_id, year_and_order, order_in_issue):
     return "".join(("S", issn_id, year, order_in_year, order_in_issue))
 
 
-def get_scielo_pid_v3(registered):
-    if registered and registered.scielo_id:
-        return registered.scielo_id
-    return scielo_id_gen.generate_scielo_pid()
-
-
-def add_article_id(article_meta, id_value, specific_use):
-    article_id = ET.Element("article-id")
-    article_id.text = id_value
-    article_id.set("specific-use", specific_use)
-    article_id.set("pub-id-type", "publisher-id")
-    article_meta.insert(0, article_id)
-
-
-def save(file_path, xml):
-    new_content = ET.tostring(xml.find(".")).decode("utf-8")
-    fs_utils.write_file(file_path, new_content)
+def add_article_id_to_xml(file_path, pid_and_specific_use_items):
+    if pid_and_specific_use_items:
+        xml = ET.parse(file_path)
+        article_meta = xml.find(".//article-meta")
+        for id_value, specific_use in pid_and_specific_use_items:
+            article_id = ET.Element("article-id")
+            article_id.text = id_value
+            article_id.set("specific-use", specific_use)
+            article_id.set("pub-id-type", "publisher-id")
+            article_meta.append(article_id)
+        new_content = ET.tostring(xml.find(".")).decode("utf-8")
+        fs_utils.write_file(file_path, new_content)

--- a/src/scielo/bin/xml/app_modules/app/db/pid_versions.py
+++ b/src/scielo/bin/xml/app_modules/app/db/pid_versions.py
@@ -1,0 +1,70 @@
+import sqlite3
+
+
+class PIDVersionsManager:
+
+    def __init__(self, db):
+        self.db = db
+
+    def insert(self, v2, v3):
+        self.db.insert(v2, v3)
+
+    def get_pid_v3(self, v2):
+        return self.db.get_pid_v3(v2)
+
+
+class PIDVersionsBD:
+
+    def __init__(self, db_name):
+        self.db_name = db_name
+        self._connection = None
+        self._cursor = None
+        self._is_table_created = None
+
+    @property
+    def conn(self):
+        if self._connection is None:
+            self._connection = sqlite3.connect(self.db_name)
+        return self._connection
+
+    @property
+    def cursor(self):
+        if self._cursor is None:
+            self._cursor = self.conn.cursor()
+        return self._cursor
+
+    @property
+    def is_table_created(self):
+        if self._is_table_created is None:
+            self._is_table_created = self.create_table()
+        return self._is_table_created
+
+    def _execute(self, command, parameters=None):
+        if self._is_table_created:
+            if parameters:
+                self.cursor.execute(command, parameters)
+            else:
+                self.cursor.execute(command)
+            if command.startswith("SELECT"):
+                return self.cursor.fetchone()
+            else:
+                self.conn.commit()
+                self.conn.close()
+                return True
+
+    def create_table(self):
+        return self._execute(
+            """CREATE TABLE IF NOT EXISTS pid_versions (v2 varchar(23) unique, v3 varchar(255) unique)"""
+        )
+
+    def insert(self, v2, v3):
+        return self._execute(
+            """INSERT INTO pid_versions VALUES ('?','?')""", (v2, v3)
+        )
+
+    def get_pid_v3(self, v2):
+        expr = (v2, )
+        found = self._execute(
+            """SELECT v3 FROM pid_versions WHERE v2 = ?""", expr)
+        if found:
+            return found[0]

--- a/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
+++ b/src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py
@@ -29,6 +29,10 @@ from ..data import aff_normalization
 from ..data import kernel_document
 from ..db import registered
 from ..db import xc_models
+from ..db.pid_versions import(
+    PIDVersionsManager,
+    PIDVersionsDB,
+)
 from . import pmc_pkgmaker
 from . import sps_pkgmaker
 
@@ -117,7 +121,7 @@ class ArticlesConversion(object):
         self.error_messages = []
         self.conversion_status = {}
 
-    def convert(self, export_documents_package=None):
+    def convert(self, export_documents_package=None, scielo_pid_v3_manager=None):
         self.articles_conversion_validations = validations_module.ValidationsResultItems()
         scilista_items = [self.pkg.issue_data.acron_issue_label]
         if self.validations_reports.blocking_errors == 0 and (self.accepted_articles == len(self.pkg.articles) or len(self.articles_mergence.excluded_orders) > 0):
@@ -125,6 +129,7 @@ class ArticlesConversion(object):
             issn_id = self.registered_issue_data.issue_models.issue.issn_id
             v36 = self.registered_issue_data.issue_models.record.get("36")
             kernel_document.add_article_id_to_received_documents(
+                scielo_pid_v3_manager,
                 issn_id, v36,
                 self.articles_mergence.accepted_articles,
                 self.articles_mergence.registered_articles,
@@ -371,7 +376,16 @@ class PkgProcessor(object):
         self.app_institutions_manager = institutions_manager.InstitutionsManager(self.config.app_ws_requester)
         self.doi_validator = doi_validations.DOIValidator(self.config.app_ws_requester)
         self.registered_issues_manager = xc_models.RegisteredIssuesManager(self.db_manager, self.journals_list)
-        
+        self._pid_manager = None
+
+    @property
+    def pid_manager(self):
+        if self._pid_manager is None and self.config.pid_manager_info:
+            self._pid_manager = PIDVersionsManager(
+                PIDVersionsDB(
+                    self.config.pid_manager_info))
+        return self._pid_manager
+
     @property
     def export_documents_package(self):
         if self.config.kernel_gate:
@@ -424,7 +438,7 @@ class PkgProcessor(object):
 
         conversion = ArticlesConversion(registered_issue_data, pkg, validations_reports, not self.config.interative_mode, self.config.local_web_app_path, self.config.web_app_site)
 
-        scilista_items = conversion.convert(self.export_documents_package)
+        scilista_items = conversion.convert(self.export_documents_package, self.pid_manager)
         
         reports = self.report_result(pkg, validations_reports, conversion)
         statistics_display = reports.validations.statistics_display(html_format=False)

--- a/src/scielo/bin/xml/tests/test_pid_versions.py
+++ b/src/scielo/bin/xml/tests/test_pid_versions.py
@@ -1,0 +1,22 @@
+import unittest
+
+from app_modules.app.data.kernel_document import (
+    PIDVersionsManager,
+    PIDVersionsDB,
+)
+
+
+class TestPIDVersionsManager(unittest.TestCase):
+
+    def setUp(self):
+        self.pid_manager = PIDVersionsManager(PIDVersionsDB("/tmp/db.db"))
+
+    def test_get_pid_v3_returns_pid_v3(self):
+        self.pid_manager.insert("pid2", "pid3")
+        self.assertEqual("pid3", self.pid_manager.get_pid_v3("pid2"))
+
+    def test_get_pid_v3_returns_none(self):
+        self.assertEqual(None, self.pid_manager.get_pid_v3("PID2"))
+
+    def tearDown(self):
+        self.pid_manager.disconnect()


### PR DESCRIPTION
#### O que esse PR faz?
Cria um gerenciador de PID da versão 3 baseado no PID da versão 2 com a intenção de ter uma forma padrão para recuperar o PID da versão 3,
pois no caso de haver uma operação de deleção de registro ISIS,
a recuperação do PID da versão 3 fica inviável.

#### Onde a revisão poderia começar?
Nesta ordem:

1. src/scielo/bin/xml/app_modules/app/config/config.py
2. src/scielo/bin/xml/app_modules/app/pkg_processors/pkg_processors.py (Linhas: 441, 381, 124)
3. src/scielo/bin/xml/app_modules/app/data/kernel_document.py
4. src/scielo/bin/xml/app_modules/app/db/pid_versions.py

#### Como este poderia ser testado manualmente?
-

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3168 

### Referências
n/a

