### PR TITLE
Gera o alt-title de title-group na posição correta que é após os títulos traduzidos

### DIFF
--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -881,6 +881,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 		<title-group>
 			<xsl:apply-templates select="doctitle[@language=$language or not(@language)] "/>
 			<xsl:apply-templates select="doctitle[@language!=$language]" mode="trans-title-group"/>
+			<xsl:apply-templates select="doctitle//alttitle"/>
 		</title-group>
 	</xsl:template>
 	<xsl:template match="article | subart | response" mode="title-group">
@@ -914,7 +915,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 		<article-title>
 			<xsl:apply-templates select="*[name()!='subtitle' and name()!='alttitle'] |text()"/>
 		</article-title>
-		<xsl:apply-templates select="subtitle|alttitle">
+		<xsl:apply-templates select="subtitle">
 			<xsl:with-param name="lang"><xsl:value-of select="@language"/></xsl:with-param>
 		</xsl:apply-templates>
 	</xsl:template>
@@ -922,7 +923,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 		<trans-title-group>
 			<xsl:apply-templates select="@language"/>
 			<trans-title>
-			<xsl:apply-templates select="*[name()!='subtitle'] |text()"></xsl:apply-templates>
+			<xsl:apply-templates select="*[name()!='subtitle' and name()!='alttitle'] |text()"></xsl:apply-templates>
 			</trans-title>
 			<xsl:apply-templates select="subtitle" mode="trans-title"/>
 		</trans-title-group>
@@ -3897,7 +3898,19 @@ et al.</copyright-statement>
 	</xsl:template>
 	
 	<xsl:template match="alttitle">
-		<xsl:param name="lang"/>
+		<xsl:param name="lang">
+			<xsl:choose>
+				<xsl:when test="@language">
+					<xsl:value-of select="@language"/>
+				</xsl:when>
+				<xsl:when test="../@language">
+					<xsl:value-of select="../@language"/>
+				</xsl:when>
+				<xsl:when test="../../@language">
+					<xsl:value-of select="../../@language"/>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:param>
 		<alt-title>
 			<xsl:if test="$lang!=''">
 				<xsl:attribute name="xml:lang"><xsl:value-of select="$lang"/></xsl:attribute>


### PR DESCRIPTION

#### O que esse PR faz?
Gera o alt-title de title-group na posição correta que é após os títulos traduzidos.
Também altera as cores das tags do markup para que sejam cores mais escuras

#### Onde a revisão poderia começar?
`src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl`

#### Como este poderia ser testado manualmente?
Usando o markup, identificando o título alternativo dentro de `[doctitle]` e depois clicar no botão "Gerar XML".

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
**Marcação de alttitle dentro de doctitle**

![Captura de Tela 2020-02-11 às 08 15 25](https://user-images.githubusercontent.com/505143/74234518-b94a6300-4cab-11ea-8dc6-08e61bd3c74d.png)

**Resultado do XML**
![Captura de Tela 2020-02-11 às 08 15 09](https://user-images.githubusercontent.com/505143/74234527-bea7ad80-4cab-11ea-8774-1d31e2a55bbb.png)


#### Quais são tickets relevantes?
#2945 

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/alt-title.html
