### PR TITLE
Não gera mais a tag <counts/>

### DIFF
--- a/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/pmc/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -890,8 +890,6 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 			
 			<xsl:apply-templates
 				select="confgrp | front//confgrp | back//bbibcom/confgrp | thesgrp | front//thesgrp | back//bbibcom/thesgrp"/>
-			
-			<xsl:apply-templates select="." mode="counts"/>
 		</article-meta>
 	</xsl:template>
 	<xsl:template match="doc | subdoc | docresp" mode="title-group">


### PR DESCRIPTION
#### O que esse PR faz?
Não gera mais a tag `<counts/>`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Usar o Markup com qualquer arquivo, gerar o XML, e verificar que não foi gerada a tag `<counts/>`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
![Captura de Tela 2020-03-03 às 15 20 08](https://user-images.githubusercontent.com/505143/75817903-bc021a80-5d76-11ea-96b7-012d4250e035.png)

#### Quais são tickets relevantes?
#3167 

### Referências
n/a
