### PR TITLE
[xc] Acrescenta ao relatório a periodicidade do periódico

### DIFF
--- a/src/scielo/bin/xml/app_modules/app/data/article.py
+++ b/src/scielo/bin/xml/app_modules/app/data/article.py
@@ -2222,6 +2222,7 @@ class Journal(object):
         self.nlm_title = None
         self.publisher_name = None
         self.license = None
+        self.frequency = None
 
 
 class ArticleXMLContent(object):

--- a/src/scielo/bin/xml/app_modules/app/db/xc_models.py
+++ b/src/scielo/bin/xml/app_modules/app/db/xc_models.py
@@ -26,6 +26,27 @@ ISSN_TYPE_CONVERSION = {
     'ppub': 'PRINT',
 }
 
+FREQ = dict([
+    ("?", "Unknown"),
+    ("A", "Annual"),
+    ("B", "Bimonthly (every two months)"),
+    ("C", "Semiweekly (twice a week)"),
+    ("D", "Daily"),
+    ("E", "Biweekly (every two weeks)"),
+    ("F", "Semiannual (twice a year)"),
+    ("G", "Biennial (every two years)"),
+    ("H", "Triennial (every three years)"),
+    ("I", "Three times a week"),
+    ("J", "Three times a month"),
+    ("K", "Irregular (known to be so)"),
+    ("M", "Monthly"),
+    ("Q", "Quarterly"),
+    ("S", "Semimonthly (twice a month)"),
+    ("T", "Three times a year"),
+    ("W", "Weekly"),
+    ("Z", "Other frequencies"),
+])
+
 
 def author_tag(is_person, is_analytic_author):
     r = {}
@@ -528,6 +549,11 @@ class RegisteredTitle(object):
     def issn_id(self):
         if self.record is not None:
             return self.record.get('400')
+
+    @property
+    def frequency(self):
+        if self.record is not None:
+            return FREQ.get(self.record.get('380'), "None")
 
 
 class IssueModels(object):
@@ -1398,6 +1424,7 @@ class DBManager(object):
                 else:
                     t = RegisteredTitle(j_record)
                     j = Journal()
+                    j.frequency = t.frequency
                     j.acron = t.acron
                     j.p_issn = t.print_issn
                     j.e_issn = t.e_issn
@@ -1410,6 +1437,7 @@ class DBManager(object):
                     j.issn_id = t.issn_id
                     j_data = Journal()
                     j_data.acron = [t.acron]
+                    j_data.frequency = [t.frequency]
                     j_data.p_issn = [t.print_issn]
                     j_data.e_issn = [t.e_issn]
                     j_data.abbrev_title = [t.abbrev_title]

--- a/src/scielo/bin/xml/app_modules/app/validations/reports_maker.py
+++ b/src/scielo/bin/xml/app_modules/app/validations/reports_maker.py
@@ -117,7 +117,12 @@ class ReportsMaker(object):
 
     @property
     def xc_validations(self):
-        r = [html_reports.tag('h3', _('Conversion Result'))]
+        r = []
+        r.append(html_reports.tag('h3', _('Frequency')))
+        r.append(
+            html_reports.tag('h4', _(self.pkg.issue_data.journal.frequency)))
+
+        r.append(html_reports.tag('h3', _('Conversion Result')))
         r.append(self.conversion.conclusion_message)
         r.append(self.articles_validations_reports.merged_articles_reports.report_articles_data_conflicts)
         r.append(self.articles_validations_reports.merged_articles_reports.report_articles_data_changes)


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta ao relatório do XC a periodicidade do periódico

#### Onde a revisão poderia começar?
de nenhum arquivo em particular

#### Como este poderia ser testado manualmente?
Executar o XC e ver o relatório gerado na aba aberta.

Num terminal
Entrar em `bin/xml`
Executar `python xml_converter.py <caminho da pasta com arquivos XML>`

#### Algum cenário de contexto que queira dar?
Só funciona no python2.7 por enquanto
Tem que ter a estrutura padrão de serial com as bases title e issue.

### Screenshots
<img width="830" alt="Captura de Tela 2020-03-25 às 17 00 51" src="https://user-images.githubusercontent.com/505143/77580849-70491980-6ebb-11ea-9d5a-edb3750ce6d4.png">

#### Quais são tickets relevantes?
#2434

### Referências
https://scielo.readthedocs.io/projects/scielo-pc-programs/en/latest/titlemanager_title.html#frequency
https://scielo.readthedocs.io/projects/scielo-pc-programs/en/latest/code_database.html

