### PR TITLE
Remove diretório de entrada (xc server) e de saída (xc server e desktop)

### DIFF
--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -4,6 +4,7 @@ import logging.config
 import argparse
 import os
 import shutil
+from tempfile import mkdtemp
 from datetime import datetime
 
 from prodtools import _
@@ -137,8 +138,7 @@ class Reception(object):
         mail_info = "subject", "message"
         result = scilista_items, xc_status, mail_info
 
-        # FIXME
-        output_path = xml_path + "_" + self.proc.stage
+        output_path = mkdtemp()
 
         pkg_maker = PackageMaker(xml_path, output_path)
         pkg = pkg_maker.pack()
@@ -159,6 +159,8 @@ class Reception(object):
                     self._update_website_files(pkg_name, acron, issue_id)
                 self._mail_results(pkg_name, mail_info)
                 self._update_report_files(pkg_name, acron, issue_id)
+        finally:
+            fs_utils.delete_file_or_folder(output_path)
 
         encoding.display_message(_('finished'))
 

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -115,6 +115,7 @@ class Reception(object):
                 "Not allowed to call _receive_package_for_server")
         for package_path in self._queued_packages():
             self.convert_package(package_path)
+            fs_utils.delete_file_or_folder(package_path)
 
     def display_form(self):
         form.display_form(


### PR DESCRIPTION
#### O que esse PR faz?
Remove diretório de entrada (xc server) e de saída (xc server e desktop) pois são gerados exclusivamente para a conversão. 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute o _XC_ antes de aplicar o PR. Note que o XC cria uma pasta com o nome da pasta do pacote de entrada + o sufixo **_xc** (pasta de saída). E ao final, esta pasta é mantida.

Execute o _XC_ após aplicar o PR. Note que no xc server, uma pasta no diretório /tmp é criada e ao final, além esta pasta ser removida, também é removida a pasta de entrada criada na pasta "queue".
No XC desktop, a pasta de entrada é mantida já não foi o XC que a criou e sim o usuário. Mas a pasta temporária é excluída pois foi criada no processo.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
```
/home/scielo/xc/workspace/scl/2020_queue/1152/1678-4766-isz-rpass-0120.zip
Package have 1 document(s)
Selected to pack 1 document(s)
Pack /home/scielo/xc/workspace/scl/2020_queue/1152/1678-4766-isz-rpass-0120.zip/1678-4766-isz-110-e2020001.xml
Optimise: /tmp/tmpetdt764m/scielo_package
Optimised: /tmp/tmpetdt764m/scielo_package
Packed: /tmp/tmpetdt764m/scielo_package
```

```
(.xc2020) scielo@dstest:~/xc/app/xc20200602/xml$ ls -ltr /tmp/tmpetdt764m
ls: cannot access '/tmp/tmpetdt764m': No such file or directory
```

```
(.xc2020) scielo@dstest:~/xc/app/xc20200602/xml$ ls -ltr /home/scielo/xc/workspace/scl/2020_queue/1152/1678-4766-isz-rpass-0120.zip
ls: cannot access '/home/scielo/xc/workspace/scl/2020_queue/1152/1678-4766-isz-rpass-0120.zip': No such file or directory

```

#### Quais são tickets relevantes?
#3210 

### Referências
n/a
