### PR TITLE
Corrige a recuperação do PID v3 para documentos ex ahead of print

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/kernel_document.py
+++ b/src/scielo/bin/xml/prodtools/data/kernel_document.py
@@ -2,18 +2,19 @@
 import xml.etree.ElementTree as ET
 
 from prodtools.utils import fs_utils
+from prodtools.db.pid_versions import PIDVersionsManager
 from . import scielo_id_gen
 
 
 def add_article_id_to_received_documents(
-    pid_manager,
-    issn_id,
-    year_and_order,
-    received_docs,
-    documents_in_isis,
-    file_paths,
-    update_article_with_aop_status,
-):
+    pid_manager: PIDVersionsManager,
+    issn_id: str,
+    year_and_order: str,
+    received_docs: dict,
+    documents_in_isis: dict,
+    file_paths: dict,
+    update_article_with_aop_status: callable,
+) -> None:
     """Atualiza article-id (scielo-v2 e scielo-v3) dos documentos recebidos.
 
     Params:

--- a/src/scielo/bin/xml/prodtools/data/kernel_document.py
+++ b/src/scielo/bin/xml/prodtools/data/kernel_document.py
@@ -6,7 +6,13 @@ from . import scielo_id_gen
 
 
 def add_article_id_to_received_documents(
-    pid_manager, issn_id, year_and_order, received_docs, documents_in_isis, file_paths
+    pid_manager,
+    issn_id,
+    year_and_order,
+    received_docs,
+    documents_in_isis,
+    file_paths,
+    update_article_with_aop_status,
 ):
     """Atualiza article-id (scielo-v2 e scielo-v3) dos documentos recebidos.
 
@@ -17,6 +23,8 @@ def add_article_id_to_received_documents(
         received_docs (dict): Pacote de documentos recebidos para processar
         documents_in_isis (dict): Documentos já registrados na base isis (acron/volnum)
         file_paths (dict): arquivos do received_docs
+        update_article_with_aop_status (callable): Função que recupera o AOP PID e modifica o
+            artigo com este dado
 
     Returns:
         None
@@ -26,6 +34,11 @@ def add_article_id_to_received_documents(
         pid_v2 = article.get_scielo_pid("v2")
         pid_v3 = article.get_scielo_pid("v3")
         pids_to_append_in_xml = []
+        # Compara o artigo com a base de artigos AOP
+        # Caso a semelhança entre os artigos seja maior que 80%
+        # O artigo recebe o PID de AOP, observável pela
+        # propriedade `registered_aop_pid`
+        update_article_with_aop_status(article)
 
         if pid_v2 and pid_v3:
             exists_in_database = pid_manager.pids_already_registered(pid_v2, pid_v3)
@@ -42,6 +55,7 @@ def add_article_id_to_received_documents(
         if pid_v3 is None:
             pid_v3 = (
                 documents_in_isis.get(xml_name, article).scielo_id
+                or pid_manager.get_pid_v3(article.registered_aop_pid)
                 or pid_manager.get_pid_v3(pid_v2)
                 or scielo_id_gen.generate_scielo_pid()
             )

--- a/src/scielo/bin/xml/prodtools/db/pid_versions.py
+++ b/src/scielo/bin/xml/prodtools/db/pid_versions.py
@@ -4,8 +4,9 @@ import logging
 CREATE_PID_TABLE_QUERY = """
     CREATE TABLE IF NOT EXISTS pid_versions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        v2 VARCHAR(23) UNIQUE,
-        v3 VARCHAR(255) UNIQUE
+        v2 VARCHAR(23),
+        v3 VARCHAR(255),
+        UNIQUE(v2, v3)
     );
 """
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -95,7 +95,7 @@ class ArticlesConversion(object):
         self.error_messages = []
         self.conversion_status = {}
 
-    def convert(self, export_documents_package=None):
+    def convert(self):
         self.articles_conversion_validations = validations_module.ValidationsResultItems()
         scilista_items = [self.pkg.issue_data.acron_issue_label]
         if self.validations_reports.blocking_errors == 0 and (self.accepted_articles == len(self.pkg.articles) or len(self.articles_mergence.excluded_orders) > 0):
@@ -118,9 +118,6 @@ class ArticlesConversion(object):
                         self.pkg.issue_data.issue_label)
                     website_files.get_files(self.pkg.package_folder.path)
                 self.registered_issue_data.issue_files.save_source_files(self.pkg.package_folder.path)
-                if export_documents_package:
-                    zip_filename = scilista_items[0].replace(" ", "_") + ".zip"
-                    export_documents_package(self.pkg.package_folder.path, zip_filename)
                 self.replace_ex_aop_pdf_files()
 
         return scilista_items
@@ -140,6 +137,22 @@ class ArticlesConversion(object):
             update_article_with_aop_status=self.db.get_valid_aop,
         )
         logger.debug("Articles that compose this package were updated with SciELO Pids (v2, and v3)")
+
+    def export_package_to_spf_directory(self, exporter: callable, package_name: str):
+        """Exporta o pacote SPS de acordo com a estratégia utilizada"""
+        if exporter is None:
+            logger.debug(
+                "Could not export this package because the none exporter was used."
+            )
+            return None
+        elif package_name is None or len(package_name) == 0:
+            logger.debug(
+                "Could not export this package because the name of package is blank."
+            )
+            return None
+
+        package_zip_name = "{}.zip".format(package_name.replace(" ", "_"))
+        exporter(self.pkg.package_folder.path, package_zip_name)
 
     @property
     def aop_status(self):
@@ -431,7 +444,16 @@ class PkgProcessor(object):
         conversion = ArticlesConversion(registered_issue_data, pkg, validations_reports, not self.config.interative_mode, self.config.local_web_app_path, self.config.web_app_site)
         if self.pid_manager is not None:
             conversion.register_pids_and_update_xmls(self.pid_manager)
-        scilista_items = conversion.convert(self.export_documents_package)
+
+        scilista_items = conversion.convert()
+
+        # A scilista sempre terá um item mas o pacote só será
+        # exportado se a scilista tiver mais de um item, isso
+        # indica que o pacote está válido
+        if scilista_items is not None and len(scilista_items) > 1:
+            conversion.export_package_to_spf_directory(
+                self.export_documents_package, package_name=scilista_items[0]
+            )
 
         reports = self.report_result(pkg, validations_reports, conversion)
         statistics_display = reports.validations.statistics_display(html_format=False)

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -429,8 +429,10 @@ class PkgProcessor(object):
         registered_issue_data, validations_reports = self.evaluate_package(pkg)
 
         conversion = ArticlesConversion(registered_issue_data, pkg, validations_reports, not self.config.interative_mode, self.config.local_web_app_path, self.config.web_app_site)
+        if self.pid_manager is not None:
+            conversion.register_pids_and_update_xmls(self.pid_manager)
         scilista_items = conversion.convert(self.export_documents_package)
-        
+
         reports = self.report_result(pkg, validations_reports, conversion)
         statistics_display = reports.validations.statistics_display(html_format=False)
 

--- a/src/scielo/bin/xml/setup.py
+++ b/src/scielo/bin/xml/setup.py
@@ -7,8 +7,8 @@ import codecs
 import sys
 
 
-if sys.version_info[0:2] < (3, 4):
-    raise RuntimeError('Requires Python 3.4 or newer')
+if sys.version_info[0:2] < (3, 5):
+    raise RuntimeError('Requires Python 3.5 or newer')
 
 with codecs.open('README.md', mode='r', encoding='utf-8') as fp:
     README = fp.read()
@@ -30,10 +30,10 @@ TESTS_REQUIRE = [
 
 if int(setuptools.__version__.split('.', 1)[0]) < 18:
     assert "bdist_wheel" not in sys.argv, "setuptools 18 required for wheels."
-    if sys.version_info[0:2] < (3, 4):
+    if sys.version_info[0:2] < (3, 5):
         INSTALL_REQUIRES.append('pathlib>=1.0.1')
 else:
-    EXTRAS_REQUIRE[':python_version<"3.4"'] = ['pathlib>=1.0.1']
+    EXTRAS_REQUIRE[':python_version<"3.5"'] = ['pathlib>=1.0.1']
 
 if sys.version_info[0:2] == (2, 7):
     TESTS_REQUIRE.append('mock')
@@ -69,7 +69,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: XML Producers and SciELO Collection Managers",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -13,6 +13,7 @@ class Article:
         self.scielo_id = scielo_id
         self.scielo_pid = scielo_pid
         self.registered_scielo_id = None
+        self.registered_aop_pid = None
         self.order = "12345"
 
     def get_scielo_pid(self, name):
@@ -21,7 +22,6 @@ class Article:
         return self.scielo_pid
 
 
-@unittest.skip("deixou de passar após PR 3171")
 class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
     def setUp(self):
         self.files = ["file" + str(i) + ".xml" for i in range(1, 6)]
@@ -53,10 +53,12 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
         year_and_order = "20173"
 
         mock_pid_manager = Mock()
+        mock_pid_manager.get_pid_v3.return_value = None
+
         kernel_document.scielo_id_gen.generate_scielo_pid = Mock(return_value="xxxxxx")
         kernel_document.add_article_id_to_received_documents(
             mock_pid_manager, issn_id, year_and_order, received,
-            registered, file_paths
+            registered, file_paths, lambda x:x
         )
 
         for name, item in received.items():


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige o bug na obtenção do PID v3 utilizado por documentos _ahead of print_ e que também deve ser utilizado pelo mesmo documentos quando for transferido para um fascículo.

#### Onde a revisão poderia começar?

Para um melhor entendimento do desenvolvimento desta funcionalidade inicie a versão pelos commits.

- Inicie em a49cac7;

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Configurar uma instância do XC (temos uma em `~/.testes`);
- Copie um pacote contendo um artigo do tipo AOP para o diretório de download;
- Execute o XC;
- Copie um novo pacote contendo o XML atualizado e referenciando um volume e número (fascículo) para o diretório de download;
- Execute o XC novamente;
- Extraia os pacotes do diretório de saída SPS (ex: `~/.testes/workspace/spf`);
- Verifique que os dois documentos apresentam diferentes PID v2;
- Verifique que os dois documentos possuem o mesmo PID v3.


#### Algum cenário de contexto que queira dar?

Este PR também tenta isolar algumas responsabilidades do código de conversão.

### Screenshots

N/A

#### Quais são tickets relevantes?

closes #3208 

### Referências
N/A

