### PR TITLE
Ajustar o logging da aplicação

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/package.py
+++ b/src/scielo/bin/xml/prodtools/data/package.py
@@ -1,15 +1,12 @@
 # coding=utf-8
 import logging
-import logging.config
 
 from prodtools.utils import xml_utils
 from prodtools.data import article
 from prodtools.data import workarea
-from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class SPPackage(object):

--- a/src/scielo/bin/xml/prodtools/data/workarea.py
+++ b/src/scielo/bin/xml/prodtools/data/workarea.py
@@ -1,17 +1,13 @@
 # coding=utf-8
 import logging
-import logging.config
 import os
 import shutil
 
 from prodtools.utils import fs_utils
 from prodtools.utils import img_utils
-from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 MARKUP_SUFFIXES = ['t', 'f', 'e', 'img', 'image']

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import logging
-import logging.config
 import os
 import shutil
 
@@ -32,12 +31,10 @@ from prodtools.db.pid_versions import(
     PIDVersionsDB,
 )
 from prodtools.processing import pmc_pkgmaker
-from prodtools.utils.logging_config import LOGGING_CONFIG
 from prodtools.db.pid_versions import PIDVersionsManager
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 EMAIL_SUBJECT_STATUS_ICON = {}

--- a/src/scielo/bin/xml/prodtools/processing/pmc_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/pmc_pkgmaker.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import logging
-import logging.config
 import os
 import shutil
 
@@ -12,11 +11,9 @@ from prodtools.validations import sps_xml_validators
 from prodtools.processing import xml_versions
 from prodtools.data import workarea
 from prodtools.data import article
-from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class PMCPackageMaker(object):

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import logging
-import logging.config
 import os
 import shutil
 from copy import deepcopy
@@ -16,11 +15,9 @@ from prodtools.data import workarea
 from prodtools.processing import symbols
 from prodtools.processing import xml_versions
 from prodtools.processing.sps_pkgmaker import PackageMaker
-from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class SGMLXML2SPSXMLError(Exception):

--- a/src/scielo/bin/xml/prodtools/server/xc_gerapadrao.py
+++ b/src/scielo/bin/xml/prodtools/server/xc_gerapadrao.py
@@ -121,7 +121,7 @@ class GeraPadrao:
         logger.info(command)
         logger.info(scilista_content)
         os.system(command)
-        logger.info('fim gerapadrao acron: %s', , self.collection_acron)
+        logger.info('fim gerapadrao acron: %s', self.collection_acron)
 
     def _update_web_site(self, scilista_content):
         if self.config.is_enabled_transference:

--- a/src/scielo/bin/xml/prodtools/server/xc_gerapadrao.py
+++ b/src/scielo/bin/xml/prodtools/server/xc_gerapadrao.py
@@ -1,20 +1,14 @@
 # coding=utf-8
 import os
 import logging
-import logging.config
 
 from datetime import datetime
 
 from prodtools.utils import fs_utils
 from prodtools.server import filestransfer
-from prodtools import LOG_PATH
 
 
-from prodtools.utils.logging_config import LOGGING_CONFIG
-
-
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class GeraPadraoStatusManager:
@@ -86,9 +80,6 @@ class GeraPadrao:
         self.status_manager = GeraPadraoStatusManager(
             self.config.gerapadrao_permission_file)
         self.col_scilista = Scilista(self.config.collection_scilista)
-        log_filename = (LOG_PATH + '/gerapadrao_' +
-                        collection_acron+'-'+self.now+'.log')
-        logging.basicConfig(filename=log_filename, filemode='w')
 
     @property
     def now(self):
@@ -126,18 +117,16 @@ class GeraPadrao:
                 self.config.email_text_gerapadrao + scilista_content)
 
         command = self.command
-        logger.info(self.now + ' - inicio gerapadrao')
+        logger.info('inicio gerapadrao acron: %s', self.collection_acron)
         logger.info(command)
         logger.info(scilista_content)
         os.system(command)
-        logger.info(self.now + ' - fim gerapadrao')
+        logger.info('fim gerapadrao acron: %s', , self.collection_acron)
 
     def _update_web_site(self, scilista_content):
         if self.config.is_enabled_transference:
-            logger.info(self.now + ' - inicio transf bases')
             transfer = filestransfer.SciELOWebFilesTransfer(self.config)
             transfer.transfer_website_bases()
-            logger.info(self.now + ' - fim transf bases')
 
         if self.mailer is not None:
             self.mailer.send_message(

--- a/src/scielo/bin/xml/prodtools/utils/dbm/dbm_isis.py
+++ b/src/scielo/bin/xml/prodtools/utils/dbm/dbm_isis.py
@@ -178,7 +178,7 @@ class IDFile(object):
         try:
             fs_utils.write_file(filename, content, 'iso-8859-1')
         except (UnicodeError, IOError, OSError) as e:
-            logger.error("Nao foi possivel escrever o arquivo %s: %s", filename, str(e))
+            logger.error("Nao foi possivel escrever o arquivo %s: %s", filename, e)
 
 
 class CISIS(object):

--- a/src/scielo/bin/xml/prodtools/utils/dbm/dbm_isis.py
+++ b/src/scielo/bin/xml/prodtools/utils/dbm/dbm_isis.py
@@ -2,12 +2,16 @@
 
 import os
 import html
+import logging
 
 from tempfile import mkdtemp, NamedTemporaryFile
 
 from prodtools.utils import fs_utils
 from prodtools.utils import encoding
 from prodtools.utils import system
+
+
+logger = logging.getLogger()
 
 
 PRESERVECIRC = '[PRESERVECIRC]'
@@ -174,8 +178,7 @@ class IDFile(object):
         try:
             fs_utils.write_file(filename, content, 'iso-8859-1')
         except (UnicodeError, IOError, OSError) as e:
-            print("Nao foi possivel escrever o arquivo {}: {}".format(
-                filename, str(e)))
+            logger.error("Nao foi possivel escrever o arquivo %s: %s", filename, str(e))
 
 
 class CISIS(object):

--- a/src/scielo/bin/xml/prodtools/utils/encoding.py
+++ b/src/scielo/bin/xml/prodtools/utils/encoding.py
@@ -1,13 +1,10 @@
 # coding=utf-8
 import logging
-import logging.config
 import sys
 import locale
-from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 LOCALE_LANG, LOCALE_ENCODING = locale.getdefaultlocale()
 SYS_DEFAULT_ENCODING = sys.getfilesystemencoding()
@@ -52,8 +49,8 @@ def report_exception(function_name, e, data):
 
 def debugging(function_name, data):
     try:
-        logger.info('DEBUG: {}'.format(function_name))
-        logger.info(data)
+        logger.debug('DEBUG: {}'.format(function_name))
+        logger.debug(data)
     except:
         logger.info('EXCEPTION at debugging()')
 

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -9,18 +9,7 @@ from ftplib import FTP, all_errors
 from datetime import datetime
 
 
-logging.basicConfig(
-    filename='./exporter.log',
-    format=u'%(asctime)s %(message)s')
-logger = logging.getLogger('Exporter')
-logger.setLevel(logging.DEBUG)
-
-
-try:
-    os.unlink('./exporter.log')
-except:
-    pass
-exp_logger = logger
+exp_logger = logging.getLogger(__name__)
 
 
 class Exporter(object):

--- a/src/scielo/bin/xml/prodtools/utils/files_extractor.py
+++ b/src/scielo/bin/xml/prodtools/utils/files_extractor.py
@@ -3,6 +3,10 @@
 import os
 import tarfile
 import zipfile
+import logging
+
+
+logger = logging.getLogger()
 
 
 def is_compressed_file(path):
@@ -37,7 +41,7 @@ def extract_file(path, to_directory='.'):
             file.close()
         r = True
     except IOError:
-        print('extract_file: Invalid file ' + path)
+        logger.error('extract_file: Invalid file ' + path)
         r = False
     finally:
         os.chdir(cwd)

--- a/src/scielo/bin/xml/prodtools/utils/logging_config.py
+++ b/src/scielo/bin/xml/prodtools/utils/logging_config.py
@@ -1,6 +1,7 @@
 
 LOGGING_CONFIG = {
     'version': 1,
+    'disable_existing_loggers': False,
     'formatters': {
         'standard': {
             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'

--- a/src/scielo/bin/xml/prodtools/utils/logging_config.py
+++ b/src/scielo/bin/xml/prodtools/utils/logging_config.py
@@ -1,7 +1,6 @@
 
 LOGGING_CONFIG = {
     'version': 1,
-    'disable_existing_loggers': True,
     'formatters': {
         'standard': {
             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
@@ -33,11 +32,23 @@ LOGGING_CONFIG = {
             'maxBytes': 10240,
             'backupCount': 3,
         },
+        'exporter': {
+            'level': 'DEBUG',
+            'formatter': 'standard',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': 'exporter.log',
+            'maxBytes': 10240,
+            'backupCount': 3,
+        },
     },
     'loggers': {
         '': {  # root logger
             'handlers': ['default', 'file', 'file2', ],
             'level': 'DEBUG',
+            'propagate': True,
+        },
+        'prodtools.utils.exporter': {  # exporter logger
+            'handlers': ['exporter'],
             'propagate': True,
         },
     }

--- a/src/scielo/bin/xml/prodtools/utils/logging_config.py
+++ b/src/scielo/bin/xml/prodtools/utils/logging_config.py
@@ -12,7 +12,7 @@ LOGGING_CONFIG = {
     },
     'handlers': {
         'default': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'formatter': 'brief',
             'class': 'logging.StreamHandler',
             'stream': 'ext://sys.stdout',  # Default is stderr
@@ -25,31 +25,11 @@ LOGGING_CONFIG = {
             'maxBytes': 10240,
             'backupCount': 3,
         },
-        'file2': {
-            'level': 'ERROR',
-            'formatter': 'standard',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'prodtools.err',
-            'maxBytes': 10240,
-            'backupCount': 3,
-        },
-        'exporter': {
-            'level': 'DEBUG',
-            'formatter': 'standard',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'exporter.log',
-            'maxBytes': 10240,
-            'backupCount': 3,
-        },
     },
     'loggers': {
         '': {  # root logger
-            'handlers': ['default', 'file', 'file2', ],
+            'handlers': ['default', 'file', ],
             'level': 'DEBUG',
-            'propagate': True,
-        },
-        'prodtools.utils.exporter': {  # exporter logger
-            'handlers': ['exporter'],
             'propagate': True,
         },
     }

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import logging
 from datetime import datetime
 
 from prodtools import _
@@ -10,6 +11,9 @@ from prodtools.reports import validation_status
 from prodtools.data import article_utils
 from prodtools.data import attributes
 from prodtools.data.article import PersonAuthor, CorpAuthor
+
+
+logger = logging.getLogger()
 
 
 log_items = []
@@ -585,7 +589,7 @@ class ArticleDisplayReport(object):
     def embedded_pdf_items(self, page_id='', width='400px', height='400px'):
         items = []
         for item in self.article.expected_pdf_files.values():
-            print(page_id + item)
+            logger.debug(page_id + item)
             items.append(html_reports.tag('p', html_reports.display_embedded_object(
                 item,
                 os.path.basename(item), page_id + item, width, height)))
@@ -666,7 +670,7 @@ def validations_table(results):
                 label, status, msg, xml = result
                 rows.append({'label': attributes.sps_help(label), 'status': status, 'message': msg, 'xml': xml, _('why it is not a valid message?'): ' '})
             else:
-                print('validations_table: ', result)
+                logger.debug('validations_table: ', result)
         r = html_reports.tag('div', html_reports.sheet(['label', 'status', 'message', 'xml', _('why it is not a valid message?')], rows, table_style='validation_sheet'))
     return r
 

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import logging
 from datetime import datetime
 
 from prodtools import _
@@ -20,6 +21,9 @@ try:
 except Exception as e:
     print(e)
     os.environ['XML_CATALOG_FILES'] = ''
+
+
+logger = logging.getLogger()
 
 
 log_items = []
@@ -155,7 +159,7 @@ class PackToolsXMLValidator(object):
         dtd_is_valid = False
         dtd_errors = []
         try:
-            print(self.sps_version)
+            logger.info(self.sps_version)
             self.xml_validator = packtools.XMLValidator.parse(
                     self.tree, sps_version=self.sps_version)
         except (packtools.etree.XMLSyntaxError, exceptions.XMLDoctypeError,
@@ -163,15 +167,15 @@ class PackToolsXMLValidator(object):
             ERR_MESSAGE = ("Validation error of {}: {}.").format(
                 self.file_path, e)
             dtd_errors = [ERR_MESSAGE]
-            print(e)
+            logger.error(e)
         except exceptions.UndefinedDTDError as e:
             dtd_errors = [str(e)]
-            print(e)
+            logger.error(e)
         else:
-            print("validate_all()")
+            logger.debug("validate_all()")
             dtd_is_valid, dtd_errors = self.xml_validator.validate_all()
             dtd_errors = xml_utils.format_validations_msg(dtd_errors)
-            print(dtd_is_valid, dtd_errors)
+            logger.debug("dtd_is_valid: %s, dtd_errors: %s", dtd_is_valid, dtd_errors)
         return dtd_is_valid, dtd_errors
 
     def validate_style(self):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -190,7 +190,8 @@ class Reception(object):
                 mail_subject, mail_content = mail_info
                 self.mailer.mail_results(pkg_name, mail_subject, mail_content)
             else:
-                logger.debug(mail_content)
+                logger.info(mail_content)
+                print(mail_content)
 
     def _update_website_files(self, package_name, acron, issue_id):
         if self.transfer:

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -28,7 +28,7 @@ from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 os_path_join = os.path.join
 
@@ -47,7 +47,7 @@ def main():
 
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+    logger.setLevel(args.loglevel.upper())
 
     package_path = args.package_path
 
@@ -169,7 +169,7 @@ class Reception(object):
             subject = subject or _("Failure during or after conversion")
             self.mailer.mail_failure(subject, package_name, msg)
         else:
-            print(msg)
+            logger.error(msg)
 
     def _update_scilista(self, package_name, scilista_items):
         if self.config.collection_scilista:
@@ -190,7 +190,7 @@ class Reception(object):
                 mail_subject, mail_content = mail_info
                 self.mailer.mail_results(pkg_name, mail_subject, mail_content)
             else:
-                print(mail_content)
+                logger.debug(mail_content)
 
     def _update_website_files(self, package_name, acron, issue_id):
         if self.transfer:

--- a/src/scielo/bin/xml/prodtools/xc_server.py
+++ b/src/scielo/bin/xml/prodtools/xc_server.py
@@ -8,7 +8,7 @@ from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 def main():
@@ -24,7 +24,7 @@ def main():
     parser.add_argument('--loglevel', default='WARNING')
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+    logger.setLevel(args.loglevel.upper())
 
     collection_acron = args.collection_acron
     call_download = args.download

--- a/src/scielo/bin/xml/prodtools/xml_pubmed.py
+++ b/src/scielo/bin/xml/prodtools/xml_pubmed.py
@@ -22,7 +22,7 @@ from prodtools.utils.logging_config import LOGGING_CONFIG
 
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 global ucisis
 
@@ -406,7 +406,7 @@ def main():
 
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+    logger.setLevel(args.loglevel.upper())
 
     issue_path = args.issue_path
     from_date = args.from_date

--- a/src/scielo/bin/xml/prodtools/xml_transform.py
+++ b/src/scielo/bin/xml/prodtools/xml_transform.py
@@ -24,7 +24,7 @@ from prodtools.utils.logging_config import LOGGING_CONFIG
 
 dictConfig(LOGGING_CONFIG)
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 def main():
@@ -52,7 +52,7 @@ def main():
 
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+    logger.setLevel(args.loglevel.upper())
 
     ctrl_filepath = args.ctrl_filepath
     err_filepath = args.err_filepath

--- a/src/scielo/bin/xml/prodtools/xpm.py
+++ b/src/scielo/bin/xml/prodtools/xpm.py
@@ -16,7 +16,7 @@ from prodtools.utils.logging_config import LOGGING_CONFIG
 
 dictConfig(LOGGING_CONFIG)
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 def display_form(stage):
@@ -99,7 +99,7 @@ def main():
 
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+    logger.setLevel(args.loglevel.upper())
 
     xml_path = args.xml_path
     acron = args.acron


### PR DESCRIPTION
#### O que esse PR faz?
Este PR se propõe a ajustar a utilização do `logging` pela aplicação. São usadas as configurações definidas no módulo `logging_config` e o nível do log é redefinido conforme argumento informado nos comandos em `--loglevel`. Também foram substituídos `print`s em tela por log de mensagens.

#### Onde a revisão poderia começar?
É recomendada que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
1. Execute os comandos `scieloxpm`, `scielojournals`, `scielo2pubmed`, `scieloxc`, `scieloxcserver` e `xml_transform` com diferentes níveis de log no argumento `--loglevel`
2. Verifique os arquivos de log `prodtools.log`, `prodtools.err` e `exporter.log` e o console e o log deve seguir a configuração do `--loglevel`
3. Verifique os pontos do código que `print`s foram substituídos pelo log

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A

#### Quais são tickets relevantes?
#3203 

### Referências
https://docs.python.org/3/howto/logging-cookbook.html
https://docs.python.org/3/library/logging.html
https://docs.python.org/3/library/logging.config.html
