### PR TITLE
Para o tipos de documentos de pareceres, cria validações para contrib/anonymous

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -551,9 +551,15 @@ class ArticleXML(object):
     def article_type_and_contrib_items(self):
         r = []
         for subart in self.translations:
-            r.append((subart.attrib.get('article-type'), subart.findall('.//contrib/collab') + subart.findall('.//contrib/name')))
+            r.append(
+                (subart.attrib.get('article-type'),
+                    subart.findall('.//contrib/collab') +
+                    subart.findall('.//contrib/name')))
         for subart in self.responses:
-            r.append((subart.attrib.get('response-type'), subart.findall('.//contrib/collab') + subart.findall('.//contrib/name')))
+            r.append(
+                (subart.attrib.get('response-type'),
+                    subart.findall('.//contrib/collab') +
+                    subart.findall('.//contrib/name')))
         return r
 
     def fn_list(self, node, scope):

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -912,7 +912,7 @@ class ArticleXML(object):
         return k
 
     @property
-    def doctype_and_contribs_items(self):
+    def doc_and_contribs_items(self):
         """
         Retorna uma lista de tuplas, cujo conteúdo é:
         (`article/@article-type` ou `sub-article/@article-type`
@@ -922,17 +922,17 @@ class ArticleXML(object):
         doc_and_contribs = []
         if self.article_meta is not None:
             doc_and_contribs.append(
-                (self.tree.find(".").get("article-type"),
+                (self.tree.find("."),
                  self.article_meta.findall('.//contrib')))
         if self.sub_articles is not None:
             for subart in self.sub_articles:
                 doc_and_contribs.append(
-                    (subart.get("article-type"), subart.findall('.//contrib')))
+                    (subart, subart.findall('.//contrib')))
 
-        for subart in self.responses:
+        for response in self.responses:
             doc_and_contribs.append(
-                (subart.attrib.get('response-type'),
-                    subart.findall('.//contrib')))
+                (response.attrib.get('response-type'),
+                    response.findall('.//contrib')))
 
         return doc_and_contribs
 

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -944,11 +944,15 @@ class ArticleXML(object):
         return contribs
 
     @property
+    def affiliations_ids(self):
+        return [aff.id for aff in self.affiliations if aff.id]
+
+    @property
     def authors_aff_xref_stats(self):
         with_aff = []
         no_aff = []
         mismatched_aff_id = []
-        aff_ids = [aff.id for aff in self.affiliations if aff.id is not None]
+        aff_ids = self.affiliations_ids
         for contrib in self.contrib_names:
             if len(contrib.xref) == 0:
                 no_aff.append(contrib)

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -547,21 +547,6 @@ class ArticleXML(object):
                 r.append({'sub-article/[@id="' + item.attrib.get('id', 'None') + '"]': self.sections(item.find('.//body'))})
         return r
 
-    @property
-    def article_type_and_contrib_items(self):
-        r = []
-        for subart in self.translations:
-            r.append(
-                (subart.attrib.get('article-type'),
-                    subart.findall('.//contrib/collab') +
-                    subart.findall('.//contrib/name')))
-        for subart in self.responses:
-            r.append(
-                (subart.attrib.get('response-type'),
-                    subart.findall('.//contrib/collab') +
-                    subart.findall('.//contrib/name')))
-        return r
-
     def fn_list(self, node, scope):
         r = []
         if node is not None:
@@ -931,7 +916,8 @@ class ArticleXML(object):
     def doctype_and_contribs_items(self):
         """
         Retorna uma lista de tuplas, cujo conteúdo é:
-        (`article/@article-type` ou `sub-article/@article-type`,
+        (`article/@article-type` ou `sub-article/@article-type`
+         ou `response/@response-type`,
          lista de `contrib`)
         """
         doc_and_contribs = []
@@ -939,10 +925,17 @@ class ArticleXML(object):
             doc_and_contribs.append(
                 (self.tree.find(".").get("article-type"),
                  self.article_meta.findall('.//contrib')))
+
         if self.sub_articles is not None:
             for subart in self.sub_articles:
                 doc_and_contribs.append(
                     (subart.get("article-type"), subart.findall('.//contrib')))
+
+        for subart in self.responses:
+            doc_and_contribs.append(
+                (subart.attrib.get('response-type'),
+                    subart.findall('.//contrib')))
+
         return doc_and_contribs
 
     @property

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -491,8 +491,7 @@ class ArticleXML(object):
             self.back = self.tree.find('.//back')
             self.translations = self.tree.findall('./sub-article[@article-type="translation"]')
             for s in self.tree.findall('./sub-article'):
-                if s.attrib.get('article-type') != 'translation':
-                    self.sub_articles.append(s)
+                self.sub_articles.append(s)
             self.responses = self.tree.findall('./response')
 
     @property
@@ -880,7 +879,7 @@ class ArticleXML(object):
         return k
 
     @property
-    def subarticle_keywords(self):
+    def translations_keywords(self):
         k = []
         for subart in self.translations:
             for node in subart.findall('.//kwd-group'):
@@ -891,7 +890,7 @@ class ArticleXML(object):
 
     @property
     def keywords(self):
-        return self.article_keywords + self.subarticle_keywords
+        return self.article_keywords + self.translations_keywords
 
     @property
     def contrib_names(self):
@@ -925,7 +924,6 @@ class ArticleXML(object):
             doc_and_contribs.append(
                 (self.tree.find(".").get("article-type"),
                  self.article_meta.findall('.//contrib')))
-
         if self.sub_articles is not None:
             for subart in self.sub_articles:
                 doc_and_contribs.append(

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -922,6 +922,24 @@ class ArticleXML(object):
         return k
 
     @property
+    def doctype_and_contribs_items(self):
+        """
+        Retorna uma lista de tuplas, cujo conteúdo é:
+        (`article/@article-type` ou `sub-article/@article-type`,
+         lista de `contrib`)
+        """
+        doc_and_contribs = []
+        if self.article_meta is not None:
+            doc_and_contribs.append(
+                (self.tree.find(".").get("article-type"),
+                 self.article_meta.findall('.//contrib')))
+        if self.sub_articles is not None:
+            for subart in self.sub_articles:
+                doc_and_contribs.append(
+                    (subart.get("article-type"), subart.findall('.//contrib')))
+        return doc_and_contribs
+
+    @property
     def article_contrib_items(self):
         k = []
         if self.article_meta is not None:

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -74,6 +74,22 @@ DOCTOPIC = {
 
 DOCTOPIC_IN_USE = DOCTOPIC.keys()
 
+PEER_REVIEW_DOCTOPICS = [
+    'aggregated-review-documents',
+    'referee-report',
+    'editor-report',
+    'author-comment',
+    'community-comment',
+    'recommendation',
+]
+
+PEER_REVIEW_CONTRIB_ROLES_FOR_ANON = [
+    'reviewer',
+    'reader',
+    'author',
+    'editor',
+]
+
 # para todos INDEXABLE validar aff, contrib, xref, ref
 INDEXABLE = [
     'research-article',
@@ -109,7 +125,6 @@ INDEXABLE_BUT_EXCEPTION = [
     'retraction',
     'partial-retraction',
 ]
-
 
 INDEXABLE_MINUS_EXCEPTIONS = list(set(INDEXABLE)-set(INDEXABLE_BUT_EXCEPTION))
 

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -166,68 +166,67 @@ class ArticleContentValidation(object):
     def validations(self):
         if self._validations is None:
             performance = []
-            #encoding.debugging(datetime.now().isoformat() + ' validations 1')
-            items = []
-            items.append(self.sps)
-            items.append(self.expiration_sps)
-            items.append(self.language)
-            items.append(self.languages)
-            items.append(self.article_type)
+            items = [
+                self.sps,
+                self.expiration_sps,
+                self.language,
+                self.languages,
+                self.article_type,
+            ]
 
             if self.article.article_meta is None:
                 items.append(('journal-meta', validation_status.STATUS_FATAL_ERROR, _('{label} is required. ').format(label='journal-meta')))
-            else:
-                items.append(self.journal_title)
-                items.append(self.publisher_name)
-                items.append(self.journal_id_publisher_id)
-                items.append(self.journal_id_nlm_ta)
-                items.append(self.journal_issns)
-
-            if self.article.article_meta is None:
                 items.append(('article-meta', validation_status.STATUS_FATAL_ERROR, _('{label} is required. ').format(label='article-meta')))
             else:
-                items.append(self.months_seasons)
-                items.append(self.issue_label)
-                items.append(self.article_date_types)
-                items.append(self.toc_section)
-                items.append(self.doi)
-                items.append(self.doi_and_lang)
-                items.append(self.article_id)
-                items.append(self.pagination)
+                items.extend([
+                    self.journal_title,
+                    self.publisher_name,
+                    self.journal_id_publisher_id,
+                    self.journal_id_nlm_ta,
+                    self.journal_issns,
+                    self.months_seasons,
+                    self.issue_label,
+                    self.article_date_types,
+                    self.toc_section,
+                    self.doi,
+                    self.doi_and_lang,
+                    self.article_id,
+                    self.pagination,
+                ])
                 if self.is_db_generation:
                     items.append(self.article_id_other)
                     items.append(self.order)
-                items.append(self.total_of_pages)
-                items.append(self.total_of_equations)
-                items.append(self.total_of_tables)
-                items.append(self.total_of_figures)
-                items.append(self.total_of_references)
-                items.append(self.ref_display_only_stats)
-                items.append(self.contrib)
-                items.append(self.contrib_id)
-                items.append(self.contrib_names)
-                items.append(self.contrib_collabs)
-                items.append(self.affiliations)
-                items.append(self.funding)
-                items.append(self.article_permissions)
-                items.append(self.history)
-                items.append(self.titles_abstracts_keywords)
+                items.extend([
+                    self.total_of_pages,
+                    self.total_of_equations,
+                    self.total_of_tables,
+                    self.total_of_figures,
+                    self.total_of_references,
+                    self.ref_display_only_stats,
+                    self.contrib,
+                    self.contrib_id,
+                    self.contrib_names,
+                    self.contrib_collabs,
+                    self.affiliations,
+                    self.funding,
+                    self.article_permissions,
+                    self.history,
+                    self.titles_abstracts_keywords,
+                    self.related_articles,
+                ])
 
-                items.append(self.related_articles)
-
-            items.append(self.sections)
-            items.append(self.paragraphs)
-            items.append(self.disp_formulas_validator.validate(self.article))
-            items.append(self.tablewrap_validator.validate(self.article))
-            items.append(self.validate_xref_reftype)
-            items.append(self.missing_xref_list)
-            #items.append(self.innerbody_elements_permissions)
-
-            items.append(self.refstats)
-            items.append(self.refs_sources)
-
+            items.extend([
+                self.sections,
+                self.paragraphs,
+                self.disp_formulas_validator.validate(self.article),
+                self.tablewrap_validator.validate(self.article),
+                self.validate_xref_reftype,
+                self.missing_xref_list,
+                self.refstats,
+                self.refs_sources,
+            ])
             r = self.normalize_validations(items)
-            encoding.debugging('fim normalize_validations', '')
+
             self._validations = (r, performance)
         return self._validations
 

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -523,12 +523,12 @@ class ArticleContentValidation(object):
                     _('{} must not have {}. ').format(
                       self.article.article_type,
                       _('contrib names or collabs')))
-        for item in self.article.article_type_and_contrib_items:
-            if (item[0] in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
-                    len(item[1]) == 0):
+        for article_type, contribs in self.article.doctype_and_contribs_items:
+            if (article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
+                    len(contribs) == 0):
                 messages.append(
                     _('{requirer} requires {required}. ').format(
-                      requirer=item[0],
+                      requirer=article_type,
                       required=_('contrib names or collabs')))
         for msg in messages:
             r.append(('contrib', validation_status.STATUS_FATAL_ERROR, msg))

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -506,33 +506,30 @@ class ArticleContentValidation(object):
     @property
     def contrib(self):
         r = []
+        messages = []
         if self.article.article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
             if (len(self.article.contrib_names) == 0 and
                     len(self.article.contrib_collabs) == 0):
-                r.append(
-                    ('contrib',
-                        validation_status.STATUS_FATAL_ERROR,
-                        _('{requirer} requires {required}. ').format(
-                            requirer=self.article.article_type,
-                            required=_('contrib names or collabs'))))
+                messages.append(
+                    _('{requirer} requires {required}. ').format(
+                        requirer=self.article.article_type,
+                        required=_('contrib names or collabs')))
         elif self.article.article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
             if (len(self.article.contrib_names) +
                     len(self.article.contrib_collabs)) > 0:
-                r.append(
-                    ('contrib',
-                     validation_status.STATUS_FATAL_ERROR,
-                     _('{} must not have {}. ').format(
-                        self.article.article_type,
-                        _('contrib names or collabs'))))
+                messages.append(
+                    _('{} must not have {}. ').format(
+                      self.article.article_type,
+                      _('contrib names or collabs')))
         for item in self.article.article_type_and_contrib_items:
             if (item[0] in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
                     len(item[1]) == 0):
-                r.append(
-                    ('contrib',
-                     validation_status.STATUS_FATAL_ERROR,
-                     _('{requirer} requires {required}. ').format(
-                        requirer=item[0],
-                        required=_('contrib names or collabs'))))
+                messages.append(
+                    _('{requirer} requires {required}. ').format(
+                      requirer=item[0],
+                      required=_('contrib names or collabs')))
+        for msg in messages:
+            r.append(('contrib', validation_status.STATUS_FATAL_ERROR, msg))
         return r
 
     @property

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -506,16 +506,10 @@ class ArticleContentValidation(object):
     @property
     def contrib(self):
         r = []
-        messages = []
         for article_type, contribs in self.article.doctype_and_contribs_items:
-            if (article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
-                    len(contribs) == 0):
-                messages.append(
-                    _('{requirer} requires {required}. ').format(
-                      requirer=article_type,
-                      required=_('contrib names or collabs')))
-        for msg in messages:
-            r.append(('contrib', validation_status.STATUS_FATAL_ERROR, msg))
+            msg = self.validate_contrib_item(article_type, contribs)
+            if msg:
+                r.append(('contrib', validation_status.STATUS_FATAL_ERROR, msg))
         return r
 
     @property
@@ -527,26 +521,19 @@ class ArticleContentValidation(object):
                 ref_validations.PersonValidation(item, aff_ids).validate())
         return r
 
-    def validate_contrib_item(self):
-        sum_contrib_names_and_contrib_collabs = (
-            len(self.article.contrib_names) +
-            len(self.article.contrib_collabs)
-        )
-        messages = []
-        article_type = self.article.article_type
+    def validate_contrib_item(self, article_type, contribs):
         if article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
-            if sum_contrib_names_and_contrib_collabs == 0:
-                messages.append(
+            if len(contribs) == 0:
+                return (
                     _('{requirer} requires {required}. ').format(
                         requirer=article_type,
                         required=_('contrib names or collabs')))
-        elif article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
-            if sum_contrib_names_and_contrib_collabs > 0:
-                messages.append(
+        if article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
+            if len(contribs) > 0:
+                return (
                     _('{} must not have {}. ').format(
                       article_type,
                       _('contrib names or collabs')))
-        return messages
 
     @property
     def contrib_collabs(self):

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -520,9 +520,12 @@ class ArticleContentValidation(object):
     @property
     def contrib_names(self):
         r = []
-        aff_ids = [aff.id for aff in self.article.affiliations if aff.id is not None]
+        aff_ids = [aff.id
+                   for aff in self.article.affiliations
+                   if aff.id is not None]
         for item in self.article.contrib_names:
-            r.extend(ref_validations.PersonValidation(item, aff_ids).validate())
+            r.extend(
+                ref_validations.PersonValidation(item, aff_ids).validate())
         return r
 
     @property

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -507,16 +507,18 @@ class ArticleContentValidation(object):
     def contrib(self):
         r = []
         messages = []
+        sum_contrib_names_and_contrib_collabs = (
+            len(self.article.contrib_names) +
+            len(self.article.contrib_collabs)
+        )
         if self.article.article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
-            if (len(self.article.contrib_names) == 0 and
-                    len(self.article.contrib_collabs) == 0):
+            if sum_contrib_names_and_contrib_collabs == 0:
                 messages.append(
                     _('{requirer} requires {required}. ').format(
                         requirer=self.article.article_type,
                         required=_('contrib names or collabs')))
         elif self.article.article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
-            if (len(self.article.contrib_names) +
-                    len(self.article.contrib_collabs)) > 0:
+            if sum_contrib_names_and_contrib_collabs > 0:
                 messages.append(
                     _('{} must not have {}. ').format(
                       self.article.article_type,

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -520,9 +520,7 @@ class ArticleContentValidation(object):
     @property
     def contrib_names(self):
         r = []
-        aff_ids = [aff.id
-                   for aff in self.article.affiliations
-                   if aff.id is not None]
+        aff_ids = self.article.affiliations_ids
         for item in self.article.contrib_names:
             r.extend(
                 ref_validations.PersonValidation(item, aff_ids).validate())

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -507,14 +507,32 @@ class ArticleContentValidation(object):
     def contrib(self):
         r = []
         if self.article.article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
-            if len(self.article.contrib_names) == 0 and len(self.article.contrib_collabs) == 0:
-                r.append(('contrib', validation_status.STATUS_FATAL_ERROR,  _('{requirer} requires {required}. ').format(requirer=self.article.article_type, required=_('contrib names or collabs'))))
+            if (len(self.article.contrib_names) == 0 and
+                    len(self.article.contrib_collabs) == 0):
+                r.append(
+                    ('contrib',
+                        validation_status.STATUS_FATAL_ERROR,
+                        _('{requirer} requires {required}. ').format(
+                            requirer=self.article.article_type,
+                            required=_('contrib names or collabs'))))
         elif self.article.article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
-            if len(self.article.contrib_names) + len(self.article.contrib_collabs) > 0:
-                r.append(('contrib', validation_status.STATUS_FATAL_ERROR,  _('{} must not have {}. ').format(self.article.article_type, _('contrib names or collabs'))))
+            if (len(self.article.contrib_names) +
+                    len(self.article.contrib_collabs)) > 0:
+                r.append(
+                    ('contrib',
+                     validation_status.STATUS_FATAL_ERROR,
+                     _('{} must not have {}. ').format(
+                        self.article.article_type,
+                        _('contrib names or collabs'))))
         for item in self.article.article_type_and_contrib_items:
-            if item[0] in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and len(item[1]) == 0:
-                r.append(('contrib', validation_status.STATUS_FATAL_ERROR, _('{requirer} requires {required}. ').format(requirer=item[0], required=_('contrib names or collabs'))))
+            if (item[0] in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
+                    len(item[1]) == 0):
+                r.append(
+                    ('contrib',
+                     validation_status.STATUS_FATAL_ERROR,
+                     _('{requirer} requires {required}. ').format(
+                        requirer=item[0],
+                        required=_('contrib names or collabs'))))
         return r
 
     @property

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -507,22 +507,6 @@ class ArticleContentValidation(object):
     def contrib(self):
         r = []
         messages = []
-        sum_contrib_names_and_contrib_collabs = (
-            len(self.article.contrib_names) +
-            len(self.article.contrib_collabs)
-        )
-        if self.article.article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
-            if sum_contrib_names_and_contrib_collabs == 0:
-                messages.append(
-                    _('{requirer} requires {required}. ').format(
-                        requirer=self.article.article_type,
-                        required=_('contrib names or collabs')))
-        elif self.article.article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
-            if sum_contrib_names_and_contrib_collabs > 0:
-                messages.append(
-                    _('{} must not have {}. ').format(
-                      self.article.article_type,
-                      _('contrib names or collabs')))
         for article_type, contribs in self.article.doctype_and_contribs_items:
             if (article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC and
                     len(contribs) == 0):
@@ -542,6 +526,27 @@ class ArticleContentValidation(object):
             r.extend(
                 ref_validations.PersonValidation(item, aff_ids).validate())
         return r
+
+    def validate_contrib_item(self):
+        sum_contrib_names_and_contrib_collabs = (
+            len(self.article.contrib_names) +
+            len(self.article.contrib_collabs)
+        )
+        messages = []
+        article_type = self.article.article_type
+        if article_type in attributes.AUTHORS_REQUIRED_FOR_DOCTOPIC:
+            if sum_contrib_names_and_contrib_collabs == 0:
+                messages.append(
+                    _('{requirer} requires {required}. ').format(
+                        requirer=article_type,
+                        required=_('contrib names or collabs')))
+        elif article_type in attributes.AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC:
+            if sum_contrib_names_and_contrib_collabs > 0:
+                messages.append(
+                    _('{} must not have {}. ').format(
+                      article_type,
+                      _('contrib names or collabs')))
+        return messages
 
     @property
     def contrib_collabs(self):

--- a/src/scielo/bin/xml/prodtools/validations/pkg_articles_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/pkg_articles_validations.py
@@ -150,7 +150,7 @@ class PkgArticlesDataReports(object):
             evaluation[k] = []
 
         for xml_name, doc in self.pkg_articles.items():
-            aff_ids = [aff.id for aff in doc.affiliations]
+            aff_ids = doc.affiliations_ids
             for contrib in doc.contrib_names:
                 if len(contrib.xref) == 0:
                     evaluation[_('authors without aff')].append(xml_name)

--- a/src/scielo/bin/xml/prodtools/validations/ref_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/ref_validations.py
@@ -106,12 +106,16 @@ class PersonValidation(object):
     def name_validation_result(self):
         r = []
         label = 'given-names'
-        result = data_validations.is_required_data(label, self.contrib.fname, validation_status.STATUS_WARNING)
+        result = data_validations.is_required_data(
+            label, self.contrib.fname, validation_status.STATUS_WARNING)
         label, status, msg = result
         if status == validation_status.STATUS_OK:
-            result = data_validations.invalid_terms_in_value(label, self.contrib.fname, ['_'], validation_status.STATUS_ERROR)
+            result = data_validations.invalid_terms_in_value(
+                label, self.contrib.fname,
+                ['_'], validation_status.STATUS_ERROR)
         r.append(result)
-        _test_number = data_validations.warn_unexpected_numbers(label, self.contrib.fname)
+        _test_number = data_validations.warn_unexpected_numbers(
+            label, self.contrib.fname)
         if _test_number is not None:
             r.append(_test_number)
         return r
@@ -120,16 +124,24 @@ class PersonValidation(object):
     def surname_validation_result(self):
         r = []
         label = 'surname'
-        label, status, msg = data_validations.is_required_data(label, self.contrib.surname)
+        label, status, msg = data_validations.is_required_data(
+            label, self.contrib.surname)
         if status == validation_status.STATUS_OK:
             msg = self.contrib.surname
             parts = self.contrib.surname.split(' ')
             if parts[-1] in attributes.identified_suffixes():
-                msg = _('{label} contains invalid {invalid_items_name}: {invalid_items}. ').format(label=u'<surname>{v}</surname>'.format(v=self.contrib.surname), invalid_items_name=_('terms'), invalid_items=parts[-1])
-                msg += _(u'{value} should be identified as {label}, if {term} is the surname, ignore this message. ').format(value=parts[-1], label=u' <suffix>' + parts[-1] + '</suffix>', term=parts[-1])
+                msg = _('{label} contains invalid {invalid_items_name}: {invalid_items}. ').format(
+                    label=u'<surname>{v}</surname>'.format(
+                        v=self.contrib.surname),
+                    invalid_items_name=_('terms'), invalid_items=parts[-1])
+                msg += _(u'{value} should be identified as {label}, if {term} is the surname, ignore this message. ').format(
+                    value=parts[-1],
+                    label=u' <suffix>' + parts[-1] + '</suffix>',
+                    term=parts[-1])
                 status = validation_status.STATUS_ERROR
                 r.append((label, status, msg))
-        _test_number = data_validations.warn_unexpected_numbers(label, self.contrib.surname)
+        _test_number = data_validations.warn_unexpected_numbers(
+            label, self.contrib.surname)
         if _test_number is not None:
             r.append(_test_number)
         return r

--- a/src/scielo/bin/xml/tests/test_article_content_validations.py
+++ b/src/scielo/bin/xml/tests/test_article_content_validations.py
@@ -1,0 +1,93 @@
+from unittest import (
+    TestCase,
+)
+from unittest.mock import (
+    Mock,
+)
+from lxml import etree
+
+
+from prodtools.validations.article_content_validations import (
+    ArticleContentValidation
+)
+
+
+class TestArticleContentValidation(TestCase):
+
+    def setUp(self):
+        self.acv = ArticleContentValidation(
+            journal=Mock(),
+            _article=Mock(),
+            pkgfiles=Mock(),
+            is_db_generation=Mock(),
+            check_url=Mock(),
+            doi_validator=Mock(),
+            config=Mock()
+        )
+        self.role_values = ('reviewer', 'reader', 'author', 'editor', )
+
+    def test_validate_peer_review_contrib_anon_retuns_empty_list(self):
+        article_type = "DUMMY"
+        text = """<article article-type="DUMMY">
+            <contrib-group>
+                <contrib><anonymous/><role specific-use="{}"/></contrib>
+            </contrib-group>
+        </article>"""
+        for role_value in self.role_values:
+            t = text.format(role_value)
+            xml = etree.fromstring(t)
+            contrib = xml.findall(".//contrib")
+            with self.subTest(i=role_value):
+                result = self.acv.validate_peer_review_contrib_anon(
+                            article_type, 2, contrib[0])
+                self.assertEqual(result, [])
+
+    def test_validate_peer_review_contrib_anon_retuns_message_because_of_wrong_value_for_role_specific_use(self):
+        article_type = "DUMMY"
+        text = """<article article-type="DUMMY">
+            <contrib-group>
+                <contrib><anonymous/><role specific-use="{}"/></contrib>
+            </contrib-group>
+        </article>"""
+        for role_value in self.role_values:
+            t = text.format("wrong-"+role_value)
+            xml = etree.fromstring(t)
+            contrib = xml.findall(".//contrib")
+            with self.subTest(i=role_value):
+                result = self.acv.validate_peer_review_contrib_anon(
+                            article_type, 2, contrib[0])
+                self.assertEqual(
+                    result,
+                    ['contrib[2] in DUMMY must have "role/@specific-use". '
+                     'Expected values: reviewer, reader, author, editor. '])
+
+    def test_validate_peer_review_contrib_anon_retuns_message_of_missing_role_if_no_specific_use_is_set(self):
+        article_type = "DUMMY"
+        text = """<article article-type="DUMMY">
+            <contrib-group>
+                <contrib><anonymous/><role/></contrib>
+            </contrib-group>
+        </article>"""
+        xml = etree.fromstring(text)
+        contrib = xml.findall(".//contrib")
+        result = self.acv.validate_peer_review_contrib_anon(
+                    article_type, 2, contrib[0])
+        self.assertEqual(
+            result,
+            ['contrib[2] in DUMMY must have "role/@specific-use". '
+             'Expected values: reviewer, reader, author, editor. '])
+
+    def test_validate_peer_review_contrib_anon_retuns_message_of_missing_role(self):
+        article_type = "DUMMY"
+        text = """<article article-type="DUMMY">
+            <contrib-group>
+                <contrib><anonymous/></contrib>
+            </contrib-group>
+        </article>"""
+        xml = etree.fromstring(text)
+        contrib = xml.findall(".//contrib")
+        result = self.acv.validate_peer_review_contrib_anon(
+                    article_type, 2, contrib[0])
+        self.assertEqual(
+            result,
+            ['contrib[2] in DUMMY must have "role"'])


### PR DESCRIPTION
#### O que esse PR faz?
Para o tipos de documentos de pareceres, cria validações para contrib/anonymous.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
1. Execute: `python xml_package_maker.py arquivo.xml`
2. Acesse o relatório na aba Validações Individuais > Validações de Conteúdo
3. Veja as validações relacionadas a "contrib".

Exemplo: [SPS-pr-subarticle.xml.zip](https://github.com/scieloorg/PC-Programs/files/4780071/SPS-pr-subarticle.xml.zip)

#### Algum cenário de contexto que queira dar?
Geralmente é exigido que todos os contrib tenham ou collab ou names. No entanto, no contexto de pareceres é possível aceitar contrib/anonymous para preservar a identidade. Em contrapartida, é necessário destacar o papel (`role`) da contribuição.

### Screenshots
<img width="1189" alt="Captura de Tela 2020-06-15 às 09 11 39" src="https://user-images.githubusercontent.com/505143/84656121-8f6aac80-aee8-11ea-8353-6cc452130a1a.png">


#### Quais são tickets relevantes?
#3220

### Referências
veja no issue #3220

