### PR TITLE
Ajusta conversão de entidades de XML para prevenir quebra de app

### DIFF
--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -38,6 +38,7 @@ class Entity2Char:
         ('&#x3C;', '<REPLACEENT>lt</REPLACEENT>'),
         ('&#60;', '<REPLACEENT>lt</REPLACEENT>'),
         ('&lt;', '<REPLACEENT>lt</REPLACEENT>'),
+        ('&amp;lt;', '<REPLACEENT>lt</REPLACEENT>'),
     )
     GT = (
         ('&#x0003E;', '<REPLACEENT>gt</REPLACEENT>'),
@@ -46,6 +47,7 @@ class Entity2Char:
         ('&#x3E;', '<REPLACEENT>gt</REPLACEENT>'),
         ('&#62;', '<REPLACEENT>gt</REPLACEENT>'),
         ('&gt;', '<REPLACEENT>gt</REPLACEENT>'),
+        ('&amp;gt;', '<REPLACEENT>gt</REPLACEENT>'),
     )
 
     def __init__(self):

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -77,6 +77,30 @@ class TextEntity2Char(TestCase):
         obj = xml_utils.Entity2Char()
         self.assertEqual(expected, obj.convert(text))
 
+    def test_convert_converts_amp_lt_entity(self):
+        text = "&amp;lt;"
+        expected = "&lt;"
+        obj = xml_utils.Entity2Char()
+        self.assertEqual(expected, obj.convert(text))
+
+    def test_convert_converts_amp_gt_entity(self):
+        text = "&amp;gt;"
+        expected = "&gt;"
+        obj = xml_utils.Entity2Char()
+        self.assertEqual(expected, obj.convert(text))
+
+    def test_convert_does_not_convert_lt_entity(self):
+        text = "&lt;"
+        expected = "&lt;"
+        obj = xml_utils.Entity2Char()
+        self.assertEqual(expected, obj.convert(text))
+
+    def test_convert_does_not_convert_gt_entity(self):
+        text = "&gt;"
+        expected = "&gt;"
+        obj = xml_utils.Entity2Char()
+        self.assertEqual(expected, obj.convert(text))
+
 
 class TestLoadXML(TestCase):
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona `&amp;lt;` e `&amp;gt;` às possíveis entidades que devem ser convertidas para um XML bem formado, permitindo que o XC faça a conversão corretamente e que a aplicação não quebre.

#### Onde a revisão poderia começar?
Em `src/scielo/bin/xml/tests/test_xml_utils.py`, para entender o que é esperado caso o conteúdo de XML seja inválido.

#### Como este poderia ser testado manualmente?
- Com o arquivo de configuração do XC no diretório `config`, nomeado com o acrônimo da coleção, e o pacote [1] no diretório de download do XC, execute o `scieloxcserver <acrônimo da coleção>`
- O pacote deve ser convertido corretamente e o XML estar de acordo.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

### Anexos
[[1] - Pacote SPS](https://drive.google.com/open?id=1qUcIhKh9H3AdFF6k_igjkZ_D0W5nJzwV)

#### Quais são tickets relevantes?
#3228

### Referências
.
