### PR TITLE
Ajusta validações considerando a nova versão SPS 1.10

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -724,11 +724,8 @@ class ArticleXML(object):
         if version_number is not None:
             if 'sps-' in version_number:
                 version_number = version_number[4:]
-            if version_number.replace('.', '').isdigit():
-                parts = version_number.split('.')
-                if len(parts) == 2:
-                    return float(version_number)
-                return float(parts[0]+'.'+''.join(parts[1:]))
+            numbers = [int(n) for n in version_number.split(".")]
+            return tuple(numbers)
 
     @property
     def article_type(self):

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -724,8 +724,12 @@ class ArticleXML(object):
         if version_number is not None:
             if 'sps-' in version_number:
                 version_number = version_number[4:]
-            numbers = [int(n) for n in version_number.split(".")]
-            return tuple(numbers)
+            try:
+                numbers = [int(n) for n in version_number.split(".")]
+            except ValueError:
+                return (0, 0)
+            else:
+                return tuple(numbers)
 
     @property
     def article_type(self):

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -586,15 +586,19 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
         if has_abstract is True:
             suggestions = ABSTRACT_REQUIRED_FOR_DOCTOPIC
         else:
-            suggestions = [item for item in DOCTOPIC_IN_USE if item not in ABSTRACT_REQUIRED_FOR_DOCTOPIC]
+            suggestions = [item
+                           for item in DOCTOPIC_IN_USE
+                           if item not in ABSTRACT_REQUIRED_FOR_DOCTOPIC]
     if article_type not in suggestions:
         suggestions_msg = _('Maybe {} is not a valid value for {}. ').format(
             article_type,
             '@article-type')
-        suggestions_msg += _('Suggested values: {}. ').format(_(' or ').join(suggestions))
+        suggestions_msg += _('Suggested values: {}. ').format(
+            _(' or ').join(suggestions))
         elem1 = '@article-type' + ' ({}) '.format(article_type)
         elem2 = 'subject' + ' (' + article_section + ')'
-        msg = _('Be sure that the elements {elem1} and {elem2} are properly identified. ').format(
+        msg = _('Be sure that the elements {elem1} and {elem2} '
+                'are properly identified. ').format(
                     elem1=elem1, elem2=elem2)
         results.append(('@article-type', status, msg + suggestions_msg))
     return results

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -1,30 +1,11 @@
 # coding=utf-8
 
-from datetime import datetime
-
 from prodtools import _
 from prodtools import TABLES_PATH
-from prodtools.data import article_utils
 from prodtools.utils.fs_utils import read_file
 from prodtools.reports import validation_status
 from prodtools.reports import html_reports
 
-
-SPS_expiration_dates = [
-    ('sps-1.9', ['20190301', '20210401']),
-    ('sps-1.8', ['20180301', '20200401']),
-    ('sps-1.7', ['20171001', '20181001']),
-    ('sps-1.6', ['20170401', '20180401']),
-    ('sps-1.5', ['20161001', '20171001']),
-    ('sps-1.4', ['20160401', '20170401']),
-    ('sps-1.3', ['20150901', '20160901']),
-    ('sps-1.2', ['20150301', '20160301']),
-    ('sps-1.1', ['20140901', '20150901']),
-    ('sps-1.0', ['20140301', '20150301']),
-    ('None', ['00000000', '20140901']),
-]
-
-dict_SPS_expiration_dates = dict(SPS_expiration_dates)
 
 REFTYPE_AND_TAG_ITEMS = {'aff': ['aff'], 'app': ['app'], 'author-notes': ['fn'], 'bibr': ['ref'], 'boxed-text': ['boxed-text'], 'contrib': ['fn'], 'corresp': ['corresp'], 'disp-formula': ['disp-formula'], 
             'fig': ['fig', 'fig-group'], 
@@ -572,33 +553,6 @@ def check_lang(lang):
         return (True, LANGUAGES.get(lang))
     else:
         return (False, _('{value} is an invalid value for {label}. ').format(value=lang, label='@xml:lang') + _('Expected values: {expected}. ').format(expected=', '.join(sorted(LANGUAGES.keys())) + '. ' + ' | '.join(sorted([k + '(' + v + ')' for k, v in LANGUAGES.items()]))))
-
-
-def expected_sps_versions(article_dateiso):
-    if article_dateiso <= SPS_expiration_dates[-1][1][0]:
-        # qualquer versao
-        return [item[0] for item in SPS_expiration_dates]
-
-    valid_versions = []
-    for version, dates in SPS_expiration_dates:
-        if dates[0] <= article_dateiso <= dates[1]:
-            valid_versions.append(version)
-    return valid_versions
-
-
-def sps_current_versions():
-    return [item[0] for item in SPS_expiration_dates[:2]]
-
-
-def sps_version_expiration_days(sps_version):
-    days = None
-    sps_dates = dict_SPS_expiration_dates.get(sps_version)
-    if sps_dates is not None:
-        sps_dates = article_utils.dateiso2datetime(sps_dates[1])
-        now = datetime.now()
-        diff = sps_dates - now
-        days = diff.days
-    return days
 
 
 def validate_article_type_and_section(article_type, article_section, has_abstract):

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -521,7 +521,6 @@ def deduce_article_type_from_article_section(section_title):
         highiest_rate, items = utils.most_similar(similarity)
         if highiest_rate > 0.8:
             suggestions = items
-        print(highiest_rate, items)
     return suggestions
 
 

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -578,10 +578,9 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
     if article_type in suggestions:
         return results
 
-    status = ''
-    suggestions_msg = ''
-    status = validation_status.STATUS_ERROR
-    if len(suggestions) == 0:
+    if len(suggestions) > 0:
+        status = validation_status.STATUS_ERROR
+    else:
         status = validation_status.STATUS_WARNING
         if has_abstract is True:
             suggestions = ABSTRACT_REQUIRED_FOR_DOCTOPIC
@@ -589,6 +588,7 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
             suggestions = [item
                            for item in DOCTOPIC_IN_USE
                            if item not in ABSTRACT_REQUIRED_FOR_DOCTOPIC]
+
     if article_type not in suggestions:
         suggestions_msg = _('Maybe {} is not a valid value for {}. ').format(
             article_type,
@@ -598,7 +598,7 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
         elem1 = '@article-type' + ' ({}) '.format(article_type)
         elem2 = 'subject' + ' (' + article_section + ')'
         msg = _('Be sure that the elements {elem1} and {elem2} '
-                'are properly identified. ').format(
+                are properly identified. ').format(
                     elem1=elem1, elem2=elem2)
         results.append(('@article-type', status, msg + suggestions_msg))
     return results

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -598,7 +598,7 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
         elem1 = '@article-type' + ' ({}) '.format(article_type)
         elem2 = 'subject' + ' (' + article_section + ')'
         msg = _('Be sure that the elements {elem1} and {elem2} '
-                are properly identified. ').format(
+                'are properly identified. ').format(
                     elem1=elem1, elem2=elem2)
         results.append(('@article-type', status, msg + suggestions_msg))
     return results

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -573,17 +573,20 @@ def validate_article_type_and_section(article_type, article_section, has_abstrac
     if article_type == article_section:
         return results
 
-    status = ''
     suggestions = deduce_article_type_from_article_section(article_section)
-    if article_type not in suggestions:
-        suggestions_msg = ''
-        status = validation_status.STATUS_ERROR
-        if len(suggestions) == 0:
-            status = validation_status.STATUS_WARNING
-            if has_abstract is True:
-                suggestions = ABSTRACT_REQUIRED_FOR_DOCTOPIC
-            else:
-                suggestions = [item for item in DOCTOPIC_IN_USE if item not in ABSTRACT_REQUIRED_FOR_DOCTOPIC]
+
+    if article_type in suggestions:
+        return results
+
+    status = ''
+    suggestions_msg = ''
+    status = validation_status.STATUS_ERROR
+    if len(suggestions) == 0:
+        status = validation_status.STATUS_WARNING
+        if has_abstract is True:
+            suggestions = ABSTRACT_REQUIRED_FOR_DOCTOPIC
+        else:
+            suggestions = [item for item in DOCTOPIC_IN_USE if item not in ABSTRACT_REQUIRED_FOR_DOCTOPIC]
     if article_type not in suggestions:
         suggestions_msg = _('Maybe {} is not a valid value for {}. ').format(
             article_type,

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -71,7 +71,7 @@ PEER_REVIEW_CONTRIB_ROLES_FOR_ANON = [
     'editor',
 ]
 
-# para todos INDEXABLE validar aff, contrib, xref, ref
+# para todos INDEXABLE exigir aff, contrib, xref, ref
 INDEXABLE = [
     'research-article',
     'article-commentary',
@@ -94,30 +94,29 @@ INDEXABLE = [
     'obituary',
     'reply',
     'data-article',
+    'aggregated-review-documents',
 ]
 
-INDEXABLE_EXCEPTIONS = {
+# para todos INDEXABLE_WITH_FLEXIBLE_REQUIREMENTS exigir aff?, contrib?, xref?, ref?
+INDEXABLE_WITH_FLEXIBLE_REQUIREMENTS = {
     'editorial': ['aff', 'contrib'],
-    'other': [],
 }
 
-INDEXABLE_BUT_EXCEPTION = [
+INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF = [
     'correction',
     'retraction',
     'partial-retraction',
+    'other',
 ]
-
-INDEXABLE_MINUS_EXCEPTIONS = list(set(INDEXABLE)-set(INDEXABLE_BUT_EXCEPTION))
-
 
 HISTORY_REQUIRED_FOR_DOCTOPIC = [
     'case-report', 
     'research-article',    
 ]
 
-AUTHORS_REQUIRED_FOR_DOCTOPIC = INDEXABLE_MINUS_EXCEPTIONS
+AUTHORS_REQUIRED_FOR_DOCTOPIC = list(set(INDEXABLE)-set(INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF))
 
-AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC = INDEXABLE_BUT_EXCEPTION
+AUTHORS_NOT_REQUIRED_FOR_DOCTOPIC = INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF
 
 ABSTRACT_REQUIRED_FOR_DOCTOPIC = [
     'brief-report', 
@@ -133,7 +132,10 @@ ABSTRACT_UNEXPECTED_FOR_DOCTOPIC = [
     'other', 
     ]
 
-REFS_REQUIRED_FOR_DOCTOPIC = list(set(INDEXABLE_MINUS_EXCEPTIONS) - {'editorial'})
+REFS_REQUIRED_FOR_DOCTOPIC = list(
+    set(INDEXABLE) -
+    set(INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF) -
+    {'editorial'})
 
 TOC_SECTIONS = { 
     u'carta': u'letter', 

--- a/src/scielo/bin/xml/prodtools/processing/xml_versions.py
+++ b/src/scielo/bin/xml/prodtools/processing/xml_versions.py
@@ -11,7 +11,7 @@ XPM_FILES.read(os.path.join(DTD_AND_XSL_PATH, 'versions.ini'))
 
 DEFAULT_VERSION = XPM_FILES.sections()[0]
 
-valid_dtd_items = ['3.0', '1.0', 'j1.0', 'j1.1']
+valid_dtd_items = XPM_FILES.sections()
 
 _SPS_VERSIONS = (
     ('None', [
@@ -59,10 +59,10 @@ SPS_VERSIONS = dict(_SPS_VERSIONS)
 def get_dtd_version(sps_version_number):
     if not sps_version_number:
         return '3.0'
-    elif float(sps_version_number) < 1.7:
-        return '1.0'
+    elif sps_version_number < (1, 7):
+        return 'j1.0'
     else:
-        return '1.1'
+        return 'j1.1'
 
 
 def xsl_getter(sps_version_number):

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/versions.ini
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/versions.ini
@@ -1,4 +1,4 @@
-[1.1]
+[j1.1]
 dtd_id = -//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN
 local = JATS-journalpublishing1.dtd
 remote = https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd
@@ -20,7 +20,7 @@ xsl_report = v3.0/xsl/nlm-style-4.6.6/style-reporter.xsl
 xsl_output_scielo = v3.0/xsl/sgml2xml/xml2pmc.xsl
 xsl_output_pmc = v3.0/xsl/sgml2xml/pmc.xsl
 
-[1.0]
+[j1.0]
 dtd_id = -//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN
 local = JATS-journalpublishing1.dtd
 remote = https://jats.nlm.nih.gov/publishing/1.0/JATS-journalpublishing1.dtd

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -252,9 +252,9 @@ class ArticleContentValidation(object):
         errors = []
         warnings = []
         if self.article.article_type in attributes.INDEXABLE:
-            if self.article.article_type not in attributes.INDEXABLE_BUT_EXCEPTION \
+            if self.article.article_type not in attributes.INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF \
                     and not self.article.is_provisional:
-                check = attributes.INDEXABLE_EXCEPTIONS.get(
+                check = attributes.INDEXABLE_WITH_FLEXIBLE_REQUIREMENTS.get(
                     self.article.article_type,
                     ['contrib', 'aff', 'xref (bibr)', 'ref']
                 )

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -465,14 +465,14 @@ class ArticleContentValidation(object):
     def publisher_name(self):
         return data_validations.is_required_data('publisher name', self.article.publisher_name, validation_status.STATUS_FATAL_ERROR)
 
-    def check_for_sps_version_number(self, number):
+    def is_sps_version_greater_than(self, number):
         if self.article.sps_version_number is not None:
-            return number <= self.article.sps_version_number
+            return self.article.sps_version_number > number
         return False
 
     @property
     def journal_id_publisher_id(self):
-        if self.check_for_sps_version_number(1.3):
+        if self.is_sps_version_greater_than((1, 3)):
             return data_validations.is_required_data('journal-id (publisher-id)', self.article.journal_id_publisher_id, validation_status.STATUS_FATAL_ERROR)
 
     @property
@@ -1012,7 +1012,7 @@ class ArticleContentValidation(object):
     @property
     def innerbody_elements_permissions(self):
         r = []
-        status = validation_status.STATUS_WARNING if self.check_for_sps_version_number(1.4) else validation_status.STATUS_INFO
+        status = validation_status.STATUS_WARNING if self.is_sps_version_greater_than((1, 4)) else validation_status.STATUS_INFO
         if len(self.article.permissions_required) > 0:
             l = [elem_id for elem_id, missing_children in self.article.permissions_required]
             if len(l) > 0:
@@ -1024,14 +1024,14 @@ class ArticleContentValidation(object):
         text_languages = sorted(list(set(self.article.trans_languages + [self.article.language] + ['en'])))
         r = []
 
-        if  self.check_for_sps_version_number(1.4):
+        if  self.is_sps_version_greater_than((1, 4)):
             for cp_elem in ['statement', 'year', 'holder']:
                 if self.article.article_copyright.get(cp_elem) is None:
                     r.append(('copyright-' + cp_elem, validation_status.STATUS_WARNING, _('It is highly recommended identifying {elem}. ').format(elem='copyright-' + cp_elem)))
         for lang, license in self.article.article_licenses.items():
 
             if lang is None:
-                if self.check_for_sps_version_number(1.4):
+                if self.is_sps_version_greater_than((1, 4)):
                     r.append(('license/@xml:lang', validation_status.STATUS_ERROR, _('{label} is required. ').format(label='license/@xml:lang')))
             elif lang not in text_languages:
                 r.append(('license/@xml:lang', validation_status.STATUS_ERROR, _('{value} is an invalid value for {label}. ').format(value=lang, label='license/@xml:lang') + _('The license text must be written in {langs}. ').format(langs=_(' or ').join(attributes.translate_code_languages(text_languages))) + _('Expected values for {label}: {expected}. ').format(label='xml:lang', expected=_(' or ').join(text_languages)), license['xml']))
@@ -1109,7 +1109,7 @@ class ArticleContentValidation(object):
             if pub_type is not None:
                 dt.append(pub_type)
 
-        if self.article.sps_version_number > 1.8:
+        if self.is_sps_version_greater_than((1, 8)):
             for fmt, date_type, pub_type, xml in self.article.raw_pubdate_items:
                 if fmt is None:
                     r.append(
@@ -1143,7 +1143,7 @@ class ArticleContentValidation(object):
                          _('@date-type must be pub or collection. '),
                          xml)
                     )
-        elif self.article.sps_version_number == 1.8:
+        elif self.article.sps_version_number == (1, 8):
             for fmt, date_type, pub_type, xml in self.article.raw_pubdate_items:
                 if date_type:
                     r.append(
@@ -1175,14 +1175,14 @@ class ArticleContentValidation(object):
                          _('@date-type is invalid for this version of SPS. '),
                          xml)
                     )
-        if self.article.sps_version_number > 1.8:
+        if self.article.sps_version_number > (1, 8):
             if self.article.is_ahead:
                 expected = [{'pub'}]
                 expected_items = 'pub'
             else:
                 expected = [{'pub', 'collection'}]
                 expected_items = 'pub|collection'
-        elif self.article.sps_version_number == 1.8:
+        elif self.article.sps_version_number == (1, 8):
             if self.article.is_ahead:
                 expected = [{'epub'}]
                 expected_items = 'epub'

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -169,7 +169,6 @@ class ArticleContentValidation(object):
             performance = []
             items = [
                 self.sps,
-                self.expiration_sps,
                 self.language,
                 self.languages,
                 self.article_type,

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -309,35 +309,14 @@ class ArticleContentValidation(object):
         status = validation_status.STATUS_INFO
         msg = version
 
-        if version in attributes.sps_current_versions():
+        if version in xml_versions.SPS_VERSIONS.keys():
             return [(label, status, msg)]
 
-        pub_dateiso = self.article.real_pubdate or self.article.expected_pubdate
-        if pub_dateiso is None:
-            return [(label, validation_status.STATUS_ERROR, _('Unable to validate sps version because article has no publication date. '))]
-        pub_dateiso = article_utils.format_dateiso(pub_dateiso)
-
-        expected_versions = list(set(attributes.expected_sps_versions(pub_dateiso) + attributes.sps_current_versions()))
-        expected_versions.sort()
-
-        if version in expected_versions:
-            status = validation_status.STATUS_INFO
-            msg = _('For articles published on {pubdate}, {sps_version} is valid. ').format(pubdate=utils.display_datetime(pub_dateiso, None), sps_version=version)
-        else:
-            status = validation_status.STATUS_ERROR
-            msg = _('For articles published on {pubdate}, {sps_version} is not valid. ').format(pubdate=utils.display_datetime(pub_dateiso, None), sps_version=version) + _('Expected SPS versions for this article: {sps_versions}. ').format(sps_versions=_(' or ').join(expected_versions))
+        status = validation_status.STATUS_BLOCKING_ERROR
+        msg = _("{}. Expected values: {}").format(
+            version,
+            ", ".join(list(xml_versions.SPS_VERSIONS.keys())))
         return [(label, status, msg)]
-
-    @property
-    def expiration_sps(self):
-        version = str(self.article.sps)
-        days = attributes.sps_version_expiration_days(version)
-        if days is None:
-            return [(_('sps expiration date'), validation_status.STATUS_WARNING, _('Unable to identify expiration date of SPS version={version}. ').format(version=version))]
-        if days < 0:
-            return [(_('sps expiration date'), validation_status.STATUS_INFO, _('{version} has expired {days} days ago. ').format(version=version, days=-1 * days))]
-        if days > 0:
-            return [(_('sps expiration date'), validation_status.STATUS_INFO, _('{version} expires in {days} days. ').format(version=version, days=days))]
 
     @property
     def language(self):

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -129,6 +129,13 @@ class PackToolsXMLValidator(object):
             return []
         errors = []
         dtd_public_id_items = xml_versions.SPS_VERSIONS.get(sps_version)
+        if dtd_public_id_items is None:
+            errors.append(
+                _('{value} is an invalid value for {label}. ').format(
+                    value=sps_version,
+                    label='article/@specific-use')
+                )
+            return errors
         if public_id not in dtd_public_id_items:
             errors.append(
                 _('{value} is an invalid value for {label}. ').format(
@@ -168,7 +175,7 @@ class PackToolsXMLValidator(object):
                 self.file_path, e)
             dtd_errors = [ERR_MESSAGE]
             logger.error(e)
-        except exceptions.UndefinedDTDError as e:
+        except (exceptions.UndefinedDTDError, ValueError) as e:
             dtd_errors = [str(e)]
             logger.error(e)
         else:


### PR DESCRIPTION
#### O que esse PR faz?
Ajusta validações considerando a nova versão SPS 1.10
- corrige bug de identificação/comparação de versão. Troca de número por tuplas
- corrige bugs que por não tratar um valor inválido para sps, levantava exceção.
- remove validação de vigência pois não seria o programa a ditar a vigência do SPS. A versão SPS 1.9 foi ampliada a sua vigência.
- inclui `aggregated-review-documents` como um novo tipo de documento indexável
- faz algumas melhorias para melhor legibilidade do código

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
`python xml_package_maker.py <arquivo.xml>`

Edite o `article/@specific-use`  para valores válidos e inválidos de SPS. Sendo que os válidos são: None, sps-1.0, sps-1.1, sps-1.2, sps-1.3, sps-1.4, sps-1.5, sps-1.6, sps-1.7, sps-1.8, sps-1.9, sps-1.10

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Antes:
Olhe no #3227

Depois:
<img width="1174" alt="Captura de Tela 2020-06-15 às 16 57 57" src="https://user-images.githubusercontent.com/505143/84702201-9e734e00-af2c-11ea-9b42-1410d157bc0d.png">

Usado o xml: 
[issue-tk3227.xml.zip](https://github.com/scieloorg/PC-Programs/files/4782780/issue-tk3227.xml.zip)

 
#### Quais são tickets relevantes?
#3227

### Referências
n/a
