### PR TITLE
Trata exceções durante a conversão de XMLs defeituosos

### DIFF
--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -190,8 +190,8 @@ class Reception(object):
         if self.mailer.mailer:
             subject = subject or _("Failure during or after conversion")
             self.mailer.mail_failure(subject, package_name, msg)
-        else:
-            logger.error(msg)
+
+        logger.error(msg)
 
     def _update_scilista(self, package_name, scilista_items):
         if self.config.collection_scilista:

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -37,6 +37,12 @@ class ForbiddenOperationError(Exception):
     pass
 
 
+class ScieloPackageError(Exception):
+    """Exceção não recuperável lançada durante a criação do objeto SPPackage"""
+
+    pass
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='XML Converter for Desktop cli utility')

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -8,6 +8,7 @@ from tempfile import mkdtemp
 from datetime import datetime
 
 from prodtools import _
+from packtools.utils import SPPackage
 
 try:
     from prodtools import form
@@ -132,6 +133,16 @@ class Reception(object):
         self.convert_package(package_path)
         return 'done', 'blue'
 
+    def _create_package_instance(self, source: str, output: str) -> SPPackage:
+        """Cria instância da classe SPPackage para o pacote de entrada"""
+
+        try:
+            package_maker = PackageMaker(source, output)
+            package = package_maker.pack()
+        except Exception as exc:
+            raise ScieloPackageError(exc) from None
+        return package
+
     def convert_package(self, package_path):
         if package_path is None:
             return False
@@ -146,9 +157,9 @@ class Reception(object):
 
         output_path = mkdtemp()
 
-        pkg_maker = PackageMaker(xml_path, output_path)
-        pkg = pkg_maker.pack()
+        pkg = self._create_package_instance(source=xml_path, output=output_path)
         pkg_name = pkg.package_folder.name
+
         try:
             result = self.proc.convert_package(pkg)
             scilista_items, xc_status, mail_info = result


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona a captura de exceções durante a conversão de pacotes SPS que possuem algum tipo de falha.

#### Onde a revisão poderia começar?
Aconselha-se a correção orientada via histórico de commits:
- Começar em e83305c;

#### Como este poderia ser testado manualmente?

Para testar este pull request, deve-se:
- Configure o XC;
- Baixe o pacote [1];
- Mova o pacote [1] para a pasta de downloads;
- Execute o XC;
- Observe que o programa não quebrou e se houver mais pacotes no diretório `download` o fluxo deve continuar.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?

#3229 

### Referências
N/A

