### PR TITLE
[markup xml] Resolve problema de "mismatched" tags por conta das tags de estilo do Word

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -505,7 +505,8 @@ class StyleTagsFixer(object):
         """
         for node in xml.findall(".//*"):
             if node.text and "[" in node.text and "]" in node.text:
-                self._restore_matched_style_tags_in_node_text(node)
+                text = self._mark_fixed_style_tags(node.text)
+                self._update_node_text(node, text)
         return xml_utils.tostring(xml)
 
     def _restore_matched_style_tags_in_node_tails(self, xml):
@@ -514,15 +515,9 @@ class StyleTagsFixer(object):
         """
         for node in xml.findall(".//*"):
             if node.tail and "[" in node.tail and "]" in node.tail:
-                self._restore_matched_style_tags_in_node_tail(node)
+                tail = self._mark_fixed_style_tags(node.tail)
+                self._update_node_tail(node, tail)
         return xml_utils.tostring(xml)
-
-    def _restore_matched_style_tags_in_node_text(self, node, fix):
-        """
-        Restaura as tags de estilo de um node.text
-        """
-        text = self._mark_fixed_style_tags(node.text)
-        self._update_node_text(node, text)
 
     def _update_node_text(self, node, node_text):
         """
@@ -540,13 +535,6 @@ class StyleTagsFixer(object):
         if not node_tag:
             return "<root>{}</root>".format(content)
         return "<root><{}>{}</{}></root>".format(node_tag, content, node_tag)
-
-    def _restore_matched_style_tags_in_node_tail(self, node, fix):
-        """
-        Restaura as tags de estilo de um node.tail
-        """
-        tail = self._mark_fixed_style_tags(node.tail)
-        self._update_node_tail(node, tail)
 
     def _update_node_tail(self, node, new_tail):
         """

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -252,14 +252,22 @@ class SGMLXMLContentEnhancer(xml_utils.SuitableXML):
         super().well_formed_xml_content()
 
     def _fix_styles(self):
-        # TODO: corrigir misplaced tags
         content = self._content
+        content = self._style_tags_upper_to_lower_case(content)
+        content = self._fix_mismatched_style_tags(content)
+        self._content = content
+
+    def _fix_mismatched_style_tags(self, content):
+        # TODO: corrigir misplaced tags
+        return content
+
+    def _style_tags_upper_to_lower_case(self, content):
         for style in ("BOLD", "ITALIC", "SUP", "SUB"):
             tag_open = "<{}>".format(style)
             tag_close = "</{}>".format(style)
             content = content.replace(tag_open, tag_open.lower())
             content = content.replace(tag_close, tag_close.lower())
-        self._content = content
+        return content
 
     def _fix_quotes(self):
         """

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -518,7 +518,8 @@ class StyleTagsFixer(object):
 
         for node in xml.findall(".//*"):
             if node.text and "[" in node.text and "]" in node.text:
-                new_xml = self._fix_loading_xml_with_recover_true(node.text)
+                new_xml = self._fix_loading_xml_with_recover_true(
+                    node.text, node.tag)
                 self._update_node_text(node, new_xml)
 
         for node in xml.findall(".//*"):
@@ -544,7 +545,8 @@ class StyleTagsFixer(object):
 
         for node in xml.findall(".//*"):
             if node.tail and "[" in node.tail and "]" in node.tail:
-                new_xml = self._fix_loading_xml_with_recover_true(node.tail)
+                new_xml = self._fix_loading_xml_with_recover_true(
+                    node.tail, None)
                 self._update_node_tail(node, new_xml)
 
         for node in xml.findall(".//*"):
@@ -590,7 +592,7 @@ class StyleTagsFixer(object):
         _xml = xml and "".join(xml.find(".").itertext())
         _content = content
         for xml_tag, sgml_tag in self.XML_TO_SGML:
-            _content = _content.replace(xml_tag, "")
+            _content = _content.replace(xml_tag.upper(), "")
         logger.debug("StyleTagsFixer._loss: content=%s", content)
         logger.debug("StyleTagsFixer._loss: _xml=%s", _xml)
         logger.debug("StyleTagsFixer._loss: _content=%s", _content)

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -512,7 +512,7 @@ class StyleTagsFixer(object):
         wrapped_node_text = self._wrapped_content(text, node.tag)
         xml, xml_error = xml_utils.load_xml(wrapped_node_text)
         if xml is None and retry:
-            xml = self._retry(text, wrapped_node_text, node.tag)
+            xml = self._retry(text, node.tag)
         if xml is not None:
             return deepcopy(xml.find(".").getchildren()[0])
 
@@ -530,7 +530,7 @@ class StyleTagsFixer(object):
         wrapped_node_tail = self._wrapped_content(tail)
         xml, xml_error = xml_utils.load_xml(wrapped_node_tail)
         if xml is None and retry:
-            xml = self._retry(tail, wrapped_node_tail)
+            xml = self._retry(tail)
 
         if xml is not None:
             node.tail = ""
@@ -548,9 +548,11 @@ class StyleTagsFixer(object):
         logger.debug("StyleTagsFixer._loss: _content=%s", _content)
         return _xml != _content
 
-    def _retry(self, content, wrapped_content, node_tag=None):
+    def _retry(self, content, node_tag=None):
         logger.debug("StyleTagsFixer._retry: %s", content)
-        # content = self._retry_inserting_tags_at_the_extremities(content)
+        content = self._retry_inserting_tags_at_the_extremities(content)
+
+        wrapped_content = self._wrapped_content(content, node_tag)
         xml = self._retry_loading_xml_with_recover_true(
             wrapped_content, content)
         return xml

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -505,7 +505,7 @@ class StyleTagsFixer(object):
         """
         for node in xml.findall(".//*"):
             if node.text and "[" in node.text and "]" in node.text:
-                self._restore_matched_style_tags_in_node_text(node, True)
+                self._restore_matched_style_tags_in_node_text(node)
         return xml_utils.tostring(xml)
 
     def _restore_matched_style_tags_in_node_tails(self, xml):
@@ -514,7 +514,7 @@ class StyleTagsFixer(object):
         """
         for node in xml.findall(".//*"):
             if node.tail and "[" in node.tail and "]" in node.tail:
-                self._restore_matched_style_tags_in_node_tail(node, True)
+                self._restore_matched_style_tags_in_node_tail(node)
         return xml_utils.tostring(xml)
 
     def _restore_matched_style_tags_in_node_text(self, node, fix):
@@ -522,9 +522,7 @@ class StyleTagsFixer(object):
         Restaura as tags de estilo de um node.text
         """
         text = self._mark_fixed_style_tags(node.text)
-        updated = self._update_node_text(node, text)
-        if not updated and fix:
-            self._fix(node, node.tag)
+        self._update_node_text(node, text)
 
     def _update_node_text(self, node, node_text):
         """
@@ -548,9 +546,7 @@ class StyleTagsFixer(object):
         Restaura as tags de estilo de um node.tail
         """
         tail = self._mark_fixed_style_tags(node.tail)
-        updated = self._update_node_tail(node, tail)
-        if not updated and fix:
-            self._fix(node)
+        self._update_node_tail(node, tail)
 
     def _update_node_tail(self, node, new_tail):
         """
@@ -582,7 +578,7 @@ class StyleTagsFixer(object):
             content = node.tail
         logger.debug("StyleTagsFixer._fix: %s", content)
         content = self._fix_inserting_tags_at_the_extremities(content)
-        
+
         wrapped_content = self._wrapped_content(content, node_tag)
         xml1, xml_error = xml_utils.load_xml(wrapped_content)
         xml2 = self._fix_loading_xml_with_recover_true(

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -14,125 +14,78 @@ class TestStyleTagsFixer(TestCase):
     def setUp(self):
         self.style_tags_fixer = sgmlxml.StyleTagsFixer()
 
-    def test_restore_matched_style_tags_in_node_text_returns_restored_style_tags(self):
+    def test_restore_matched_style_tags_in_node_texts_returns_style_tags_in_upper_case(self):
         text = """<root><p>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</p></root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        new_node = self.style_tags_fixer._restore_matched_style_tags_in_node_text(node)
-        expected = """<p>texto 1 <sup><bold>sup bold</bold></sup> texto 2</p>"""
-        self.assertEqual(
-            expected, xml_utils.tostring(new_node))
-
-    def test_restore_matched_style_tags_in_node_text_does_not_restore_because_they_are_mismatched(self):
-        text = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        new_node = self.style_tags_fixer._restore_matched_style_tags_in_node_text(node)
-        self.assertIsNone(xml_utils.tostring(new_node))
-
-    def test_restore_matched_style_tags_in_node_texts_returns_restored_style_tags(self):
-        text = """<root><p>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</p></root>"""
-        expected = """<root><p>texto 1 <sup><bold>sup bold</bold></sup> texto 2</p></root>"""
+        expected = """<root><p>texto 1 <SUP><BOLD>sup bold</BOLD></SUP> texto 2</p></root>"""
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
             self.style_tags_fixer._restore_matched_style_tags_in_node_texts(
                 xml))
 
-    def test_restore_matched_style_tags_in_node_texts_does_not_restore_because_they_are_mismatched(self):
+    def test_restore_matched_style_tags_in_node_texts_fixes_mismatched_tags(self):
         text = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
-        expected = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
         xml = xml_utils.etree.fromstring(text)
-        self.assertEqual(
-            expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(
-                xml))
+        result = self.style_tags_fixer._restore_matched_style_tags_in_node_texts(
+                xml)
+        self.assertIn("<SUP>", result)
+        self.assertIn("</SUP>", result)
+        self.assertIn("<BOLD>", result)
+        self.assertIn("</BOLD>", result)
 
-    def test_restore_matched_style_tags_in_node_tail_returns_restored_style_tags(self):
+    def test_fix_loading_xml_with_recover_true_fixes_mismatched_tags(self):
+        text = """texto 1 [sup][bold]sup bold[/sup][/bold] texto 2"""
+        xml = self.style_tags_fixer._fix_loading_xml_with_recover_true(
+            text, None)
+        result = xml_utils.tostring(xml)
+        self.assertIn("<SUP>", result)
+        self.assertIn("</SUP>", result)
+        self.assertIn("<BOLD>", result)
+        self.assertIn("</BOLD>", result)
+
+    def test_restore_matched_style_tags_in_node_tails_returns_style_tags_in_upper_case(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(node)
-        self.assertEqual(node.tail, "texto 1 ")
-        self.assertEqual(
-            xml_utils.tostring(node.getnext()),
-            "<sup><bold>sup bold</bold></sup>")
-        self.assertEqual(node.getnext().tail, " texto 2")
-
-    def test_restore_matched_style_tags_in_node_tail_does_not_restore_because_they_are_mismatched(self):
-        text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(node)
-        self.assertEqual(
-            node.tail, "texto 1 [sup][bold]sup bold[/sup][/bold] texto 2")
-
-    def test_restore_matched_style_tags_in_node_tail_with_fix_true_restores_them_although_they_are_mismatched(self):
-        text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
-            node, fix=True)
-        self.assertEqual(node.tail, "texto 1 ")
-        self.assertEqual(
-            xml_utils.tostring(node.getnext()),
-            "<sup><bold>sup bold</bold></sup>")
-        self.assertEqual(node.getnext().tail, " texto 2")
-
-    def test_restore_matched_style_tags_in_node_tail_with_fix_true_restores_sup_although_it_is_not_closed(self):
-        text = """<root><p/>texto 1 [sup]sup bold texto 2</root>"""
-        xml = xml_utils.etree.fromstring(text)
-        node = xml.find(".//p")
-        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
-            node, fix=True)
-        self.assertEqual(node.tail, "texto 1 ")
-        self.assertEqual(
-            xml_utils.tostring(node.getnext()),
-            "<sup>sup bold texto 2</sup>")
-        self.assertEqual(node.getnext().tail, None or "")
-
-    def test_restore_matched_style_tags_in_node_tails_returns_restored_style_tags(self):
-        text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
-        expected = """<root><p/>texto 1 <sup><bold>sup bold</bold></sup> texto 2</root>"""
+        expected = """<root><p/>texto 1 <SUP><BOLD>sup bold</BOLD></SUP> texto 2</root>"""
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
             self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
                 xml))
 
-    def test_restore_matched_style_tags_in_node_tails_does_not_restore_because_they_are_mismatched(self):
+    def test_restore_matched_style_tags_in_node_tails_fixes_mismatched_tags(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
-        expected = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
         xml = xml_utils.etree.fromstring(text)
-        self.assertEqual(
-            expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
-                xml))
+        result = self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
+                xml)
+        self.assertIn("<SUP>", result)
+        self.assertIn("</SUP>", result)
+        self.assertIn("<BOLD>", result)
+        self.assertIn("</BOLD>", result)
 
     def test_fix_inserting_tags_at_the_extremities_insert_at_the_start(self):
-        text = """texto 1 </sup> texto 2"""
-        expected = """<sup>texto 1 </sup> texto 2"""
+        text = """texto 1 [/sup] texto 2"""
+        expected = """<SUP>texto 1 </SUP> texto 2"""
         result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
     def test_fix_inserting_tags_at_the_extremities_insert_at_the_end(self):
-        text = """texto 1 <sup> texto 2"""
-        expected = """texto 1 <sup> texto 2</sup>"""
+        text = """texto 1 [sup] texto 2"""
+        expected = """texto 1 <SUP> texto 2</SUP>"""
         result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
     def test_fix_inserting_tags_at_the_extremities_insert_at_the_start_repeatly(self):
-        text = """texto 1 </sup></bold></italic></sub> texto 2"""
-        expected = """<sub><italic><bold><sup>texto 1 </sup></bold></italic></sub> texto 2"""
+        text = """texto 1 [/sup][/bold][/italic][/sub] texto 2"""
+        expected = """<SUB><ITALIC><BOLD><SUP>texto 1 </SUP></BOLD></ITALIC></SUB> texto 2"""
         result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
     def test_fix_inserting_tags_at_the_extremities_insert_at_the_end_repeatly(self):
-        text = """texto 1 <sub><italic><bold><sup> texto 2"""
-        expected = """texto 1 <sub><italic><bold><sup> texto 2</sup></bold></italic></sub>"""
+        text = """texto 1 [sub][italic][bold][sup] texto 2"""
+        expected = """texto 1 <SUB><ITALIC><BOLD><SUP> texto 2</SUP></BOLD></ITALIC></SUB>"""
         result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+import sys
+from unittest import TestCase
+
+from prodtools.processing import sgmlxml
+from prodtools.utils import xml_utils
+
+
+python_version = sys.version_info.major
+
+
+class TestStyleTagsFixer(TestCase):
+
+    def setUp(self):
+        self.style_tags_fixer = sgmlxml.StyleTagsFixer()
+
+    def test_restore_matched_style_tags_in_node_text_returns_restored_style_tags(self):
+        text = """<root><p>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</p></root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        new_node = self.style_tags_fixer._restore_matched_style_tags_in_node_text(node)
+        expected = """<p>texto 1 <sup><bold>sup bold</bold></sup> texto 2</p>"""
+        self.assertEqual(
+            expected, xml_utils.tostring(new_node))
+
+    def test_restore_matched_style_tags_in_node_text_does_not_restore_because_they_are_mismatched(self):
+        text = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        new_node = self.style_tags_fixer._restore_matched_style_tags_in_node_text(node)
+        self.assertIsNone(xml_utils.tostring(new_node))
+
+    def test_restore_matched_style_tags_in_node_texts_returns_restored_style_tags(self):
+        text = """<root><p>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</p></root>"""
+        expected = """<root><p>texto 1 <sup><bold>sup bold</bold></sup> texto 2</p></root>"""
+        xml = xml_utils.etree.fromstring(text)
+        self.assertEqual(
+            expected,
+            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(xml))
+
+    def test_restore_matched_style_tags_in_node_texts_does_not_restore_because_they_are_mismatched(self):
+        text = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
+        expected = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
+        xml = xml_utils.etree.fromstring(text)
+        self.assertEqual(
+            expected,
+            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(xml))
+

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -67,24 +67,24 @@ class TestStyleTagsFixer(TestCase):
         self.assertEqual(
             node.tail, "texto 1 [sup][bold]sup bold[/sup][/bold] texto 2")
 
-    def test_restore_matched_style_tags_in_node_tail_with_retry_true_restores_them_although_they_are_mismatched(self):
+    def test_restore_matched_style_tags_in_node_tail_with_fix_true_restores_them_although_they_are_mismatched(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
         xml = xml_utils.etree.fromstring(text)
         node = xml.find(".//p")
         self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
-            node, retry=True)
+            node, fix=True)
         self.assertEqual(node.tail, "texto 1 ")
         self.assertEqual(
             xml_utils.tostring(node.getnext()),
             "<sup><bold>sup bold</bold></sup>")
         self.assertEqual(node.getnext().tail, " texto 2")
 
-    def test_restore_matched_style_tags_in_node_tail_with_retry_true_restores_sup_although_it_is_not_closed(self):
+    def test_restore_matched_style_tags_in_node_tail_with_fix_true_restores_sup_although_it_is_not_closed(self):
         text = """<root><p/>texto 1 [sup]sup bold texto 2</root>"""
         xml = xml_utils.etree.fromstring(text)
         node = xml.find(".//p")
         self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
-            node, retry=True)
+            node, fix=True)
         self.assertEqual(node.tail, "texto 1 ")
         self.assertEqual(
             xml_utils.tostring(node.getnext()),
@@ -109,30 +109,30 @@ class TestStyleTagsFixer(TestCase):
             self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
                 xml))
 
-    def test_retry_inserting_tags_at_the_extremities_insert_at_the_start(self):
+    def test_fix_inserting_tags_at_the_extremities_insert_at_the_start(self):
         text = """texto 1 </sup> texto 2"""
         expected = """<sup>texto 1 </sup> texto 2"""
-        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+        result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
-    def test_retry_inserting_tags_at_the_extremities_insert_at_the_end(self):
+    def test_fix_inserting_tags_at_the_extremities_insert_at_the_end(self):
         text = """texto 1 <sup> texto 2"""
         expected = """texto 1 <sup> texto 2</sup>"""
-        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+        result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
-    def test_retry_inserting_tags_at_the_extremities_insert_at_the_start_repeatly(self):
+    def test_fix_inserting_tags_at_the_extremities_insert_at_the_start_repeatly(self):
         text = """texto 1 </sup></bold></italic></sub> texto 2"""
         expected = """<sub><italic><bold><sup>texto 1 </sup></bold></italic></sub> texto 2"""
-        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+        result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
-    def test_retry_inserting_tags_at_the_extremities_insert_at_the_end_repeatly(self):
+    def test_fix_inserting_tags_at_the_extremities_insert_at_the_end_repeatly(self):
         text = """texto 1 <sub><italic><bold><sup> texto 2"""
         expected = """texto 1 <sub><italic><bold><sup> texto 2</sup></bold></italic></sub>"""
-        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+        result = self.style_tags_fixer._fix_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -110,14 +110,14 @@ class TestStyleTagsFixer(TestCase):
                 xml))
 
     def test_retry_inserting_tags_at_the_extremities_insert_at_the_start(self):
-        text = """texto 1 [/sup] texto 2"""
+        text = """texto 1 </sup> texto 2"""
         expected = """<sup>texto 1 </sup> texto 2"""
         result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
 
     def test_retry_inserting_tags_at_the_extremities_insert_at_the_end(self):
-        text = """texto 1 [sup] texto 2"""
+        text = """texto 1 <sup> texto 2"""
         expected = """texto 1 <sup> texto 2</sup>"""
         result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
             text)

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -122,3 +122,17 @@ class TestStyleTagsFixer(TestCase):
         result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
             text)
         self.assertEqual(expected, result)
+
+    def test_retry_inserting_tags_at_the_extremities_insert_at_the_start_repeatly(self):
+        text = """texto 1 </sup></bold></italic></sub> texto 2"""
+        expected = """<sub><italic><bold><sup>texto 1 </sup></bold></italic></sub> texto 2"""
+        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+            text)
+        self.assertEqual(expected, result)
+
+    def test_retry_inserting_tags_at_the_extremities_insert_at_the_end_repeatly(self):
+        text = """texto 1 <sub><italic><bold><sup> texto 2"""
+        expected = """texto 1 <sub><italic><bold><sup> texto 2</sup></bold></italic></sub>"""
+        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+            text)
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -108,3 +108,17 @@ class TestStyleTagsFixer(TestCase):
             expected,
             self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
                 xml))
+
+    def test_retry_inserting_tags_at_the_extremities_insert_at_the_start(self):
+        text = """texto 1 [/sup] texto 2"""
+        expected = """<sup>texto 1 </sup> texto 2"""
+        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+            text)
+        self.assertEqual(expected, result)
+
+    def test_retry_inserting_tags_at_the_extremities_insert_at_the_end(self):
+        text = """texto 1 [sup] texto 2"""
+        expected = """texto 1 <sup> texto 2</sup>"""
+        result = self.style_tags_fixer._retry_inserting_tags_at_the_extremities(
+            text)
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -46,3 +46,37 @@ class TestStyleTagsFixer(TestCase):
             expected,
             self.style_tags_fixer._restore_matched_style_tags_in_node_texts(xml))
 
+    def test_restore_matched_style_tags_in_node_tail_returns_restored_style_tags(self):
+        text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(node)
+        self.assertEqual(node.tail, "texto 1 ")
+        self.assertEqual(
+            xml_utils.tostring(node.getnext()),
+            "<sup><bold>sup bold</bold></sup>")
+        self.assertEqual(node.getnext().tail, " texto 2")
+
+    def test_restore_matched_style_tags_in_node_tail_does_not_restore_because_they_are_mismatched(self):
+        text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(node)
+        self.assertEqual(
+            node.tail, "texto 1 [sup][bold]sup bold[/sup][/bold] texto 2")
+
+    def test_restore_matched_style_tags_in_node_tails_returns_restored_style_tags(self):
+        text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
+        expected = """<root><p/>texto 1 <sup><bold>sup bold</bold></sup> texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        self.assertEqual(
+            expected,
+            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(xml))
+
+    def test_restore_matched_style_tags_in_node_tails_does_not_restore_because_they_are_mismatched(self):
+        text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
+        expected = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        self.assertEqual(
+            expected,
+            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(xml))

--- a/src/scielo/bin/xml/tests/test_sgmlxml.py
+++ b/src/scielo/bin/xml/tests/test_sgmlxml.py
@@ -36,7 +36,8 @@ class TestStyleTagsFixer(TestCase):
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(xml))
+            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(
+                xml))
 
     def test_restore_matched_style_tags_in_node_texts_does_not_restore_because_they_are_mismatched(self):
         text = """<root><p>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</p></root>"""
@@ -44,7 +45,8 @@ class TestStyleTagsFixer(TestCase):
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(xml))
+            self.style_tags_fixer._restore_matched_style_tags_in_node_texts(
+                xml))
 
     def test_restore_matched_style_tags_in_node_tail_returns_restored_style_tags(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
@@ -65,13 +67,38 @@ class TestStyleTagsFixer(TestCase):
         self.assertEqual(
             node.tail, "texto 1 [sup][bold]sup bold[/sup][/bold] texto 2")
 
+    def test_restore_matched_style_tags_in_node_tail_with_retry_true_restores_them_although_they_are_mismatched(self):
+        text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
+            node, retry=True)
+        self.assertEqual(node.tail, "texto 1 ")
+        self.assertEqual(
+            xml_utils.tostring(node.getnext()),
+            "<sup><bold>sup bold</bold></sup>")
+        self.assertEqual(node.getnext().tail, " texto 2")
+
+    def test_restore_matched_style_tags_in_node_tail_with_retry_true_restores_sup_although_it_is_not_closed(self):
+        text = """<root><p/>texto 1 [sup]sup bold texto 2</root>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        self.style_tags_fixer._restore_matched_style_tags_in_node_tail(
+            node, retry=True)
+        self.assertEqual(node.tail, "texto 1 ")
+        self.assertEqual(
+            xml_utils.tostring(node.getnext()),
+            "<sup>sup bold texto 2</sup>")
+        self.assertEqual(node.getnext().tail, None or "")
+
     def test_restore_matched_style_tags_in_node_tails_returns_restored_style_tags(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/bold][/sup] texto 2</root>"""
         expected = """<root><p/>texto 1 <sup><bold>sup bold</bold></sup> texto 2</root>"""
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(xml))
+            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
+                xml))
 
     def test_restore_matched_style_tags_in_node_tails_does_not_restore_because_they_are_mismatched(self):
         text = """<root><p/>texto 1 [sup][bold]sup bold[/sup][/bold] texto 2</root>"""
@@ -79,4 +106,5 @@ class TestStyleTagsFixer(TestCase):
         xml = xml_utils.etree.fromstring(text)
         self.assertEqual(
             expected,
-            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(xml))
+            self.style_tags_fixer._restore_matched_style_tags_in_node_tails(
+                xml))


### PR DESCRIPTION
#### O que esse PR faz?
Os XML gerados a partir do documento marcado pode estar quebrado por conta das tags de estilos que são geradas a partir dos estilos do Word e não a partir das etiquetas dos elementos do Markup. 

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
TODO...

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
TODO

#### Quais são tickets relevantes?
#3201 

### Referências
n/a
