### PR TITLE
Altera SuitableXML (adequação de XML) para retornar conteúdo original com erro no parser de XML.

### DIFF
--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -213,11 +213,7 @@ class SuitableXML(object):
                 xml_declaration=self.xml_declaration,
                 pretty_print=pretty_print, doctype=doctype
                 ).decode("utf-8")
-        return "\n".join([
-                self.xml_declaration,
-                self.doctype,
-                self.content,
-            ])
+        return self.original
 
     def write(self, dest_file_path, pretty_print=True,
               dtd_location_type=None):

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -301,6 +301,15 @@ class TestSuitableXML(TestCase):
         self.assertEqual(suitable_xml.doctype, '')
         self.assertIsNone(suitable_xml.xml_declaration)
 
+    def test_init_no_xml(self):
+        text = "Qualquer texto nao XML."
+        suitable_xml = xml_utils.SuitableXML(text)
+        self.assertEqual(suitable_xml.format(), text)
+        self.assertIsNotNone(suitable_xml.xml_error)
+        self.assertIn("it must be an XML content or XML file path", suitable_xml.xml_error)
+        self.assertIsNone(suitable_xml.doctype)
+        self.assertIsNone(suitable_xml.xml_declaration)
+
     def test_init_xml_with_no_xml_declaration(self):
         text = ('<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal '
                 'Publishing DTD v1.1 20151215//EN" '
@@ -318,6 +327,17 @@ class TestSuitableXML(TestCase):
             '<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal '
             'Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/'
             'publishing/1.1/JATS-journalpublishing1.dtd">\n<article/>')
+
+    def test_init_invalid_xml_should_return_original(self):
+        text = ('<?xml version="1.0" encoding="utf-8"?>'
+                '<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal '
+                'Publishing DTD v1.1 20151215//EN" '
+                '"https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">'
+                '\n<article>'
+                '<p><ext-link ext-link-type="uri" xlink:href="<link-invalido>">bla</ext-link></p>'
+                '</article>')
+        suitable_xml = xml_utils.SuitableXML(text)
+        self.assertEqual(suitable_xml.format(), text)
 
     def test_init_xml_with_no_doctype(self):
         text = '<?xml version="1.0" encoding="utf-8"?><doc/>'


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige retorno de `SuitableXML.format()` para retornar o valor original da entrada, seja de arquivo ou string. Este valor só retornará caso não seja possível fazer o parse do XML.

#### Onde a revisão poderia começar?
Em `src/scielo/bin/xml/prodtools/utils/xml_utils.py`

#### Como este poderia ser testado manualmente?
- Execute o XPM com arquivo XML inválido.
- O programa não deve quebrar durante a tentativa de adequar o XML (`SuitableXML`) e conseguirá direcionar para o validador
- Execute o primeiro passo com um XML válido e o programa também não deve quebrar.

#### Algum cenário de contexto que queira dar?
Foi possível identificar este problema por conta de outro erro que já foi corrigido anteriormente. Forçando alguns testes foi possível identificar uma situação em que, sem a correção, o XML declaration e o DOCTYPE eram duplicados caso o conteúdo original os possuísse.

### Screenshots
N/A

#### Quais são tickets relevantes?
#3224, apesar do erro relatado no ticket não ocorrer mais.

### Referências
.
