### PR TITLE
Altera para INFO o status de validação a respeito do DOI de artigo

### DIFF
--- a/src/scielo/bin/xml/prodtools/validations/doi_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/doi_validations.py
@@ -121,7 +121,7 @@ class DOIValidator(object):
     def validate_journal_title(self, article_journal_title, article_doi,
                                doi_data):
         if doi_data.journal_titles is not None:
-            status = validation_status.STATUS_ERROR
+            status = validation_status.STATUS_INFO
             if article_journal_title not in doi_data.journal_titles:
                 max_rate, items = utils.most_similar(
                     utils.similarity(
@@ -136,7 +136,7 @@ class DOIValidator(object):
 
     def validate_article_title(self, article_titles, article_doi, doi_data):
         if doi_data.article_titles is not None:
-            status = validation_status.STATUS_ERROR
+            status = validation_status.STATUS_INFO
             max_rate = 0
             for t in article_titles:
                 rate, items = utils.most_similar(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera relatório do Package Maker para exibir mensagem como `INFO` ao invés de `ERROR` quando houver problema de validação de periódico e título do documento do DOI de presente no XML.

#### Onde a revisão poderia começar?
Em `src/scielo/bin/xml/prodtools/validations/doi_validations.py`.

#### Como este poderia ser testado manualmente?
- Execute o XPM para um XML que contenha DOI registrado para outro título de outro periódico [1].
- Abra o relatório e clique em `Validações Individuais` > `Validações de conteúdo`
- Observe as mensagens de validação do DOI, que devem aparecer como `INFO` ao invés de `ERROR`.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
Mensagem de validação do DOI

<img width="1170" alt="Screen Shot 2020-06-19 at 09 51 48" src="https://user-images.githubusercontent.com/18053487/85134660-4336a980-b213-11ea-853c-02a1a3f74cf0.png">

### Anexos
[1] - [2523-3106-adr-60-31.xml.zip](https://github.com/scieloorg/PC-Programs/files/4779768/2523-3106-adr-60-31.xml.zip)

#### Quais são tickets relevantes?
#3225 

### Referências
.