### PR TITLE
Corrige envio de e-mails durante a conversão de pacotes e passa a logar eventuais exceções

### DIFF
--- a/docs/source/xc.md
+++ b/docs/source/xc.md
@@ -249,6 +249,8 @@ EMAIL_TEXT_GERAPADRAO=email_gerapadrao.txt
 
 EMAIL_SUBJECT_INVALID_PACKAGES=[XC_VERSION] [COLLECTION_NAME] Invalid packages
 EMAIL_TEXT_INVALID_PACKAGES=email_invalid_packages.txt
+
+EMAIL_SUBJECT_CONVERSION_FAILURE=[XC_VERSION] [COLLECTION_NAME] Packages conversion failure
 ```
 
 #### Recepção de pacotes por FTP

--- a/src/scielo/bin/xml/config/collection.xc.ini
+++ b/src/scielo/bin/xml/config/collection.xc.ini
@@ -51,3 +51,5 @@ EMAIL_TEXT_GERAPADRAO=email_gerapadrao.txt
 
 EMAIL_SUBJECT_INVALID_PACKAGES=[SciELO-XML] [Brasil] Invalid packages
 EMAIL_TEXT_INVALID_PACKAGES=email_invalid_packages.txt
+
+EMAIL_SUBJECT_CONVERSION_FAILURE=[SciELO-XML] [Brasil] Packages conversion failure

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -279,6 +279,9 @@ class Configuration(object):
     def email_to(self):
         return self._data.get('EMAIL_TO')
 
+    def email_subject_conversion_failure(self):
+        return self._data.get('EMAIL_SUBJECT_CONVERSION_FAILURE')
+
     @property
     def email_subject_packages_receipt(self):
         return self._data.get('EMAIL_SUBJECT_PACKAGES_RECEIPT')

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -28,16 +28,12 @@ class Mailer(object):
         if self.config.is_enabled_email_service:
             self.send_message(self.config.email_to, self.config.email_subject_invalid_packages, self.config.email_text_invalid_packages + '\n'.join(invalid_pkg_files))
 
-    def mail_failure(self, subject, package_folder, e):
-        if self.config.is_enabled_email_service:
-            subject = ("{}: {}").format(
-                    self.config.email_subject_invalid_packages.replace(
-                        "Invalid packages", subject),
-                    package_folder)
-            self.send_message(
-                self.config.email_to,
-                subject,
-                '\n' + package_folder + '\n' + str(e))
+    def mail_failure(self, subject: str, text: str, package: str) -> None:
+        """Informa falhas gerais ocorridas durante a conversão de pacotes SPS"""
+        subject = "{} {}: {}".format(
+            self.config.email_subject_invalid_packages, subject, package
+        )
+        self.send_message(self.config.email_to, subject, text)
 
     def mail_results(self, package_folder, results, report_location):
         if self.config.is_enabled_email_service:

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -31,7 +31,7 @@ class Mailer(object):
     def mail_failure(self, subject: str, text: str, package: str) -> None:
         """Informa falhas gerais ocorridas durante a conversão de pacotes SPS"""
         subject = "{} {}: {}".format(
-            self.config.email_subject_invalid_packages, subject, package
+            self.config.email_subject_conversion_failure, subject, package
         )
         self.send_message(self.config.email_to, subject, text)
 

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -1,7 +1,8 @@
-# coding=utf-8
+import logging
 
 from prodtools.utils import email_service
 
+LOGGER = logging.getLogger(__name__)
 
 class Mailer(object):
 
@@ -13,6 +14,14 @@ class Mailer(object):
                 config.email_server)
 
     def send_message(self, to, subject, text, attaches=[]):
+        if not self.config.is_enabled_email_service:
+            LOGGER.info("Could not send this email. The mailer service is disabled")
+            return None
+        elif self.mailer is None:
+            LOGGER.info(
+                "Could not send this email. The mailer service isn't configured"
+            )
+            return None
         self.mailer.send_message(to, subject, text, attaches)
 
     def mail_invalid_packages(self, invalid_pkg_files):

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -33,7 +33,7 @@ class Mailer(object):
         subject = "{} {}: {}".format(
             self.config.email_subject_conversion_failure, subject, package
         )
-        self.send_message(self.config.email_to, subject, text)
+        self.send_message(self.config.email_to_adm, subject, text)
 
     def mail_results(self, package_folder, results, report_location):
         if self.config.is_enabled_email_service:

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -4,6 +4,7 @@ import logging.config
 import argparse
 import os
 import shutil
+import traceback
 
 from tempfile import TemporaryDirectory
 from datetime import datetime
@@ -151,8 +152,14 @@ class Reception(object):
                 package = self._create_package_instance(source=xml_path, output=output_path)
                 scilista_items, xc_status, mail_info = self.proc.convert_package(package)
             except Exception:
-                self.inform_failure(
-                    package_path, "Could not convert package '%s'." % package_path
+                logger.exception(
+                    "Could not convert the package '%s'. The following traceback was captured: ",
+                    package_path,
+                )
+                self.mailer.mail_failure(
+                    subject="Could not convert the package",
+                    text=traceback.format_exc(),
+                    package=package_path,
                 )
             else:
                 if scilista_items is None or len(scilista_items) == 0:

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -179,6 +179,7 @@ class Reception(object):
         encoding.display_message(_('finished'))
 
     def _update_scilista(self, package_name, scilista_items):
+        """Atualiza a scilista da coleção no path configurado"""
         if self.config.collection_scilista:
             try:
                 content = '\n'.join(list(set(scilista_items))) + '\n'
@@ -186,9 +187,17 @@ class Reception(object):
                     self.config.collection_scilista,
                     content)
             except Exception as e:
-                msg = _("Unable to update scilista {} with {}: {}"
-                        ).format(self.config.collection_scilista, content, e)
-                self.inform_failure(package_name, msg)
+                subject = _("Unable to update scilista {} with {}").format(
+                    self.config.collection_scilista, content
+                )
+                logger.exception(
+                    "Could not update the scilista '%s' with '%s",
+                    self.config.collection_scilista,
+                    content,
+                )
+                self.mailer.mail_failure(
+                    subject=subject, text=traceback.format_exc(), package=package_name
+                )
                 raise e
 
     def _mail_results(self, pkg_name, mail_info):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -88,9 +88,12 @@ class Reception(object):
                     configuration.email_text_packages_receipt +
                     '\n' + ftp.registered_actions)
         except Exception as e:
-            self.inform_failure(
-                "", str(e),
-                subject=_('Something went wrong as downloading packages'))
+            logger.exception(
+                "Could not download packages. The following traceback was captured: "
+            )
+            self.mailer.mail_failure(
+                subject="Could not download packages", text=traceback.format_exc(),
+            )
             raise e
 
     def receive_package(self, package_path=None):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -218,9 +218,13 @@ class Reception(object):
             try:
                 self.transfer.transfer_website_files(acron, issue_id)
             except Exception as e:
-                msg = _("Unable to transfer xml, pdf, images files"
-                        " of {} {}: {}").format(acron, issue_id, e)
-                self.inform_failure(package_name, msg)
+                subject = _(
+                    "Unable to transfer xml, pdf, images files of {} {}"
+                ).format(acron, issue_id)
+                logger.exception(subject)
+                self.mailer.mail_failure(
+                    subject=subject, text=traceback.format_exc(), package=package_name
+                )
                 raise e
 
     def _update_report_files(self, package_name, acron, issue_id):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -186,13 +186,6 @@ class Reception(object):
 
         encoding.display_message(_('finished'))
 
-    def inform_failure(self, package_name, msg, subject=None):
-        if self.mailer.mailer:
-            subject = subject or _("Failure during or after conversion")
-            self.mailer.mail_failure(subject, package_name, msg)
-
-        logger.error(msg)
-
     def _update_scilista(self, package_name, scilista_items):
         if self.config.collection_scilista:
             try:

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -39,12 +39,6 @@ class ForbiddenOperationError(Exception):
     pass
 
 
-class ScieloPackageError(Exception):
-    """Exceção não recuperável lançada durante a criação do objeto SPPackage"""
-
-    pass
-
-
 def main():
     parser = argparse.ArgumentParser(
         description='XML Converter for Desktop cli utility')
@@ -137,12 +131,8 @@ class Reception(object):
     def _create_package_instance(self, source: str, output: str) -> SPPackage:
         """Cria instância da classe SPPackage para o pacote de entrada"""
 
-        try:
-            package_maker = PackageMaker(source, output)
-            package = package_maker.pack()
-        except Exception as exc:
-            raise ScieloPackageError(exc) from None
-        return package
+        package_maker = PackageMaker(source, output)
+        return package_maker.pack()
 
     def convert_package(self, package_path):
         if package_path is None:
@@ -160,11 +150,6 @@ class Reception(object):
             try:
                 package = self._create_package_instance(source=xml_path, output=output_path)
                 scilista_items, xc_status, mail_info = self.proc.convert_package(package)
-            except ScieloPackageError:
-                self.inform_failure(
-                    package_path,
-                    "Could not create package from source path '%s'." % package_path,
-                )
             except Exception:
                 self.inform_failure(
                     package_path, "Could not convert package '%s'." % package_path

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -232,9 +232,13 @@ class Reception(object):
             try:
                 self.transfer.transfer_report_files(acron, issue_id)
             except Exception as e:
-                msg = _("Unable to transfer report files"
-                        " of {} {}: {}").format(acron, issue_id, e)
-                self.inform_failure(package_name, msg)
+                subject = _("Unable to transfer report files of {} {}").format(
+                    acron, issue_id
+                )
+                logger.exception(subject)
+                self.mailer.mail_failure(
+                    subject=subject, text=traceback.format_exc(), package=package_name
+                )
                 raise e
 
     def _queued_packages(self):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -109,8 +109,15 @@ class Reception(object):
             try:
                 self.convert_package(package_path)
             except Exception as e:
-                self.inform_failure(
-                    package_path, str(e), "receive_package_for_desktop")
+                logger.exception(
+                    "Could not receive packages for desktop of path '%s'",
+                    package_path,
+                )
+                self.mailer.mail_failure(
+                    subject="Could not receive packages for desktop",
+                    text=traceback.format_exc(),
+                    package=package_path,
+                )
                 raise
 
     def _receive_package_for_server(self):

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -201,13 +201,17 @@ class Reception(object):
                 raise e
 
     def _mail_results(self, pkg_name, mail_info):
-        if self.mailer.mailer:
-            if mail_info and self.config.email_subject_package_evaluation:
-                mail_subject, mail_content = mail_info
-                self.mailer.mail_results(pkg_name, mail_subject, mail_content)
-            else:
-                logger.info(mail_content)
-                print(mail_content)
+        if (
+            mail_info is not None
+            and len(mail_info) == 2
+            and self.config.is_enabled_email_service
+            and self.config.email_subject_package_evaluation
+        ):
+            mail_subject, mail_content = mail_info
+            self.mailer.mail_results(pkg_name, mail_subject, mail_content)
+        else:
+            logger.info(pkg_name, mail_info)
+            print(pkg_name, mail_info)
 
     def _update_website_files(self, package_name, acron, issue_id):
         if self.transfer:


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige falhas no envio de e-mails pelo XC, também faz com que as exceções sejam exibidas em detalhes durante a execução do programa.

#### Onde a revisão poderia começar?

Recomendo fortemente que a revisão seja feita a partir do histórico de commits, comece em: 2d22d4b17f248931718a7cda78ea10acc1996aa1.

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente, deve-se:
- Configure o XC;
- Utilize um pacote SPS com xmls quebrados. Recomendo a utilização do pacote `~/.testes/TestePaty/src/scielo/bin/xml/k/malformado.zip` disponível do dsteste;
- Execute o XC com o sistema de e-mails configurado;
- O admin cadastrado no arquivo _ini_ da coleção deve receber um e-mail com os detalhes dos erros;
- Novamente execute o XC com o sistema de e-mails desligado;
- O admin não deve receber e-mail algum e o programa não deve quebrar;
- No dsteste ou no seu ambiente de testes, desligue o servidor SMTP (ex: `sudo systemctl stop sendmail`);
- Habilite o envio de e-mails pelo XC;
Execute novamente o processamento;
- O admin não deve receber o e-mail mas o sistema não deve quebrar pelo fato do servidor de SMTP não estar disponível.

#### Algum cenário de contexto que queira dar?

N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#3230 

### Referências
N/A

