### PR TITLE
CRediT: gera o XML para a marcação `credit/@uri`

### DIFF
--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1009,7 +1009,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 			<xsl:apply-templates select="@*[name()!='rid']"/>
 			<xsl:apply-templates select=".//authorid"/>
 			<xsl:apply-templates select="."/>
-			<xsl:apply-templates select=".//xref|role"/>
+			<xsl:apply-templates select=".//xref|role|credit"/>
 			<xsl:if test="not(.//xref) and count(../..//afftrans)+count(../..//normaff)+count(../..//aff)=1">
 				<xref ref-type="aff" rid="aff1"/>
 			</xsl:if>
@@ -1021,6 +1021,9 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 			<xsl:apply-templates mode="copy-of"  select="../..//aff[@id=$author_rid]/role"/>
 			<xsl:apply-templates mode="copy-of"  select="../..//normaff[@id=$author_rid]/role"/>
 		</contrib>
+	</xsl:template>
+	<xsl:template match="credit">
+		<role content-type="{@uri}"><xsl:value-of select="."/></role>
 	</xsl:template>
 	<xsl:template match="role"><role><xsl:apply-templates/></role></xsl:template>
 	<xsl:template match="corpauth" mode="front-contrib">


### PR DESCRIPTION
#### O que esse PR faz?
CRediT: gera o XML para a marcação `credit/@uri`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Usando o programa de marcação, após marcado, clicar no botão "Gerar XML"

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="727" alt="Captura de Tela 2020-06-19 às 23 32 18" src="https://user-images.githubusercontent.com/505143/85189536-520a7400-b286-11ea-83b8-7568c69fc579.png">


#### Quais são tickets relevantes?
#3152

### Referências
n/a
