### PR TITLE
Ao gerar o pacote de XML, preservar o estilo `italic` mesmo que envolva o conteúdo inteiro dos elementos

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -116,10 +116,10 @@ class SPSXMLContent(xml_utils.SuitableXML):
         As tags de estilo não devem ser aplicadas no conteúdo inteiro de
         certos elementos. As tags de estilo somente pode destacar partes do
         conteúdo de um dado elemento
-        <source><italic>texto texto texto</italic></source> - não aceitável
-        <source><italic>texto</italic> texto texto</source> - aceitável
+        <source><bold>texto texto texto</bold></source> - não aceitável
+        <source><bold>texto</bold> texto texto</source> - aceitável
         """
-        STYLES = ("italic", "bold")
+        STYLES = ("bold", )
         nodes = []
         for style in STYLES:
             nodes.extend(self.xml.findall(".//{}[{}]".format(tag, style)))

--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -114,7 +114,7 @@ class SPSXMLContent(xml_utils.SuitableXML):
     def remove_styles_off_tagged_content(self, tag):
         """
         As tags de estilo não devem ser aplicadas no conteúdo inteiro de
-        certos elementos. As tags de estilo somente pode destacar partes do
+        certos elementos. As tags de estilo somente podem destacar partes do
         conteúdo de um dado elemento
         <source><bold>texto texto texto</bold></source> - não aceitável
         <source><bold>texto</bold> texto texto</source> - aceitável
@@ -122,7 +122,7 @@ class SPSXMLContent(xml_utils.SuitableXML):
         STYLES = ("bold", )
         nodes = []
         for style in STYLES:
-            nodes.extend(self.xml.findall(".//{}[{}]".format(tag, style)))
+            nodes.extend(self.xml.xpath(".//{}[.//{}]".format(tag, style)))
         for node in set(nodes):
             xml_utils.merge_siblings_style_tags_content(node, STYLES)
             xml_utils.remove_styles_off_tagged_content(node, STYLES)

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -174,7 +174,7 @@ class SuitableXML(object):
             self.changed = True
 
         self._xml, self.xml_error = load_xml(
-            self._content, recover=self.recover)
+            self._content, remove_blank_text=False, recover=self.recover)
 
     def well_formed_xml_content(self):
         xml_content = self._content
@@ -350,11 +350,14 @@ def tostring(node, pretty_print=False, with_tail=False):
                 ))
 
 
-def load_xml(str_or_filepath, remove_blank_text=True, validate=False, recover=False):
+def load_xml(str_or_filepath, remove_blank_text=False, validate=False, recover=False):
     """
     Retorna uma árvore de XML e erros (se ocorrer ao carregá-lo)
     Pode receber o XML em str ou caminho de um arquivo
     Usado na conversao do Markup para XML
+
+    remove_blank_text:
+        remove os espaços entre dois elementos
     """
     parser = etree.XMLParser(
         remove_blank_text=remove_blank_text,
@@ -423,7 +426,7 @@ def load_html(file_path):
 
 
 def pretty_print(content):
-    xml, error = load_xml(content)
+    xml, error = load_xml(content, remove_blank_text=True)
     return tostring(xml, pretty_print=True)
 
 

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -45,6 +45,13 @@ class TestSPSXMLContent(TestCase):
         obj.remove_styles_off_tagged_content("source")
         self.assertEqual(obj.content, expected)
 
+    def test_remove_styles_off_tagged_content_removes_bold_because_it_wraps_whole_source(self):
+        text = "<root><source><italic><bold>texto 1</bold> <bold>texto 2</bold></italic></source></root>"
+        expected = "<root><source><italic>texto 1 texto 2</italic></source></root>"
+        obj = sps_pkgmaker.SPSXMLContent(text)
+        obj.remove_styles_off_tagged_content("source")
+        self.assertEqual(obj.content, expected)
+
     def test_remove_uri_off_contrib_id(self):
         text = """<contrib-group>
         <contrib contrib-type="author">

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -11,9 +11,16 @@ python_version = sys.version_info.major
 
 class TestSPSXMLContent(TestCase):
 
-    def test_remove_styles_off_tagged_content_removes_all_italics(self):
-        text = "<root><source><italic>texto 1</italic> <italic>texto 2</italic></source></root>"
+    def test_remove_styles_off_tagged_content_removes_all_bolds(self):
+        text = "<root><source><bold>texto 1</bold> <bold>texto 2</bold></source></root>"
         expected = "<root><source>texto 1 texto 2</source></root>"
+        obj = sps_pkgmaker.SPSXMLContent(text)
+        obj.remove_styles_off_tagged_content("source")
+        self.assertEqual(obj.content, expected)
+
+    def test_remove_styles_off_tagged_content_removes_no_italics(self):
+        text = "<root><source><italic>texto 1</italic> <italic>texto 2</italic></source></root>"
+        expected = "<root><source><italic>texto 1</italic> <italic>texto 2</italic></source></root>"
         obj = sps_pkgmaker.SPSXMLContent(text)
         obj.remove_styles_off_tagged_content("source")
         self.assertEqual(obj.content, expected)

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -25,9 +25,9 @@ class TestSPSXMLContent(TestCase):
         obj.remove_styles_off_tagged_content("source")
         self.assertEqual(obj.content, expected)
 
-    def test_remove_styles_off_tagged_content_removes_bold_and_italics(self):
+    def test_remove_styles_off_tagged_content_removes_bold_and_keep_italics(self):
         text = "<root><source><bold> <italic>texto 1</italic> <italic>texto 2</italic> </bold></source></root>"
-        expected = "<root><source>texto 1 texto 2</source></root>"
+        expected = "<root><source> <italic>texto 1</italic> <italic>texto 2</italic> </source></root>"
         obj = sps_pkgmaker.SPSXMLContent(text)
         obj.remove_styles_off_tagged_content("source")
         self.assertEqual(obj.content, expected)

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -40,7 +40,7 @@ class TestSPSXMLContent(TestCase):
 
     def test_remove_styles_off_tagged_content_does_not_remove_italic(self):
         text = "<root><source><bold> <italic>texto 1</italic> sem estilo <italic>texto 2</italic> </bold></source></root>"
-        expected = "<root><source><italic>texto 1</italic> sem estilo <italic>texto 2</italic> </source></root>"
+        expected = "<root><source> <italic>texto 1</italic> sem estilo <italic>texto 2</italic> </source></root>"
         obj = sps_pkgmaker.SPSXMLContent(text)
         obj.remove_styles_off_tagged_content("source")
         self.assertEqual(obj.content, expected)

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -104,6 +104,73 @@ class TextEntity2Char(TestCase):
 
 class TestLoadXML(TestCase):
 
+    def test_print_pretty_result_depends_on_the_param_remove_blank_text_of_load_xml(self):
+        xml_input = (
+            "<root><source><italic>texto 1</italic> <italic>texto 2</italic>"
+            "</source></root>"
+        )
+        xml_with_blank_text_as_false, errors = xml_utils.load_xml(
+            xml_input, remove_blank_text=False)
+        result_with_blank_text_as_false = xml_utils.tostring(
+            xml_with_blank_text_as_false, pretty_print=True)
+
+        xml_with_blank_text_as_true, errors = xml_utils.load_xml(
+            xml_input, remove_blank_text=True)
+        result_with_blank_text_as_true = xml_utils.tostring(
+            xml_with_blank_text_as_true, pretty_print=True)
+
+        self.assertNotEqual(
+            result_with_blank_text_as_false, result_with_blank_text_as_true)
+        self.assertEqual(
+            result_with_blank_text_as_false,
+            "<root>\n"
+            "  <source><italic>texto 1</italic> <italic>"
+            "texto 2</italic></source>\n"
+            "</root>\n"
+        )
+        self.assertEqual(
+            result_with_blank_text_as_true,
+            "<root>\n"
+            "  <source>\n"
+            "    <italic>texto 1</italic>\n"
+            "    <italic>texto 2</italic>\n"
+            "  </source>\n"
+            "</root>\n"
+        )
+
+    def test_tostring_result_depends_on_the_param_remove_blank_text_of_load_xml(self):
+        xml_input = (
+            "<root><source><italic>texto 1</italic> <italic>texto 2</italic>"
+            "</source></root>"
+        )
+        xml_with_blank_text_as_false, errors = xml_utils.load_xml(
+            xml_input, remove_blank_text=False)
+        result_with_blank_text_as_false = xml_utils.tostring(
+            xml_with_blank_text_as_false)
+
+        xml_with_blank_text_as_true, errors = xml_utils.load_xml(
+            xml_input, remove_blank_text=True)
+        result_with_blank_text_as_true = xml_utils.tostring(
+            xml_with_blank_text_as_true)
+
+        self.assertNotEqual(
+            result_with_blank_text_as_false, result_with_blank_text_as_true)
+
+        self.assertEqual(
+            result_with_blank_text_as_false,
+            "<root>"
+            "<source><italic>texto 1</italic> <italic>"
+            "texto 2</italic></source>"
+            "</root>"
+        )
+        self.assertEqual(
+            result_with_blank_text_as_true,
+            "<root>"
+            "<source><italic>texto 1</italic><italic>"
+            "texto 2</italic></source>"
+            "</root>"
+        )
+
     def test_load_xml_successfully_from_str(self):
         xml, e = xml_utils.load_xml("<root/>")
         self.assertIsNone(e)
@@ -157,6 +224,31 @@ class TestLoadXML(TestCase):
             errors,
             "Loading XML from 'str': CharRef: invalid decimal value, "
             "line 1, column 14 (<string>, line 1)")
+
+    def test_load_xml_with_remove_blank_text_as_true_remove_blanks(self):
+        xml_input = (
+            "<root><source><italic>texto 1</italic> <italic>texto 2</italic>"
+            "</source></root>"
+        )
+        expected = (
+            "<root><source><italic>texto 1</italic><italic>texto 2</italic>"
+            "</source></root>"
+        )
+        xml, errors = xml_utils.load_xml(xml_input, remove_blank_text=True)
+        result = xml_utils.tostring(xml)
+        self.assertEqual(expected, result)
+
+    def test_load_xml_with_remove_blank_text_as_false_keep_blanks(self):
+        xml_input = (
+            "<root><source><italic>texto 1</italic> <italic>texto 2</italic>"
+            "</source></root>"
+        )
+        xml, errors = xml_utils.load_xml(
+            "<root><source><italic>texto 1</italic> <italic>texto 2</italic>"
+            "</source></root>",
+            remove_blank_text=False)
+        result = xml_utils.tostring(xml)
+        self.assertEqual(xml_input, result)
 
 
 class TestRemoveStylesTags(TestCase):
@@ -374,4 +466,3 @@ class TestSuitableXML(TestCase):
         suitable_xml = xml_utils.SuitableXML(text)
         suitable_xml.well_formed_xml_content()
         self.assertEqual(expected, suitable_xml.content)
-


### PR DESCRIPTION
#### O que esse PR faz?
Como o itálico pode identificar nomes científicos, mesmo  que envolva o conteúdo inteiro dos elementos source, article-title, translate-title e kwd, deve ser mantido.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Execute o XPM para os arquivos em anexo:
```python xml_package_maker.py <pasta>```

Verifique que os `italic` são preservados

[jvatitd-26.zip](https://github.com/scieloorg/PC-Programs/files/4815881/jvatitd-26.zip)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3244

### Referências
n/a
