### PR TITLE
Insere quebra de linhas no XML para que no resultado da validação fique fácil de localizar os erros.

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -367,7 +367,7 @@ class PackageMaker(object):
             fs_utils.unzip(zip_optimised, self.destination_path)
             logger.debug("Optimised: %s", self.destination_path)
         except (PackageMakerOptimiserPreReqError, SPPackageError,
-                OSError, DecompressionBombError):
+                OSError, DecompressionBombError, xml_utils.etree.XMLSyntaxError):
             if self.destination_path != doc_pkg_path:
                 for f in files:
                     shutil.copy(f, self.destination_path)

--- a/src/scielo/bin/xml/prodtools/reports/html_reports.css
+++ b/src/scielo/bin/xml/prodtools/reports/html_reports.css
@@ -643,6 +643,8 @@ h5 {
     border: 5px solid #55C3DC;
     padding: 2px;
     display: none;
+    font-size: 12pt;
+
 }
 .report-block-datarep {
     border: 5px solid #EFBDC0;

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -213,11 +213,7 @@ class SuitableXML(object):
                 xml_declaration=self.xml_declaration,
                 pretty_print=pretty_print, doctype=doctype
                 ).decode("utf-8")
-        return "\n".join([
-                self.xml_declaration,
-                self.doctype,
-                self.content,
-            ])
+        return self.original
 
     def write(self, dest_file_path, pretty_print=True,
               dtd_location_type=None):

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -232,41 +232,35 @@ class SuitableXML(object):
                 pretty_print=pretty_print, doctype=doctype)
 
 
-class XMLinMultipleLines(object):
+def insert_break_lines(content):
+    """
+    Modifica o conteúdo XML em várias linhas para que ao ser validado fique
+    fácil de localizar o erro pelo número da linha
+    """
+    if content:
+        xml, error = load_xml(content, remove_blank_text=True)
+        if xml:
+            content = tostring(xml, pretty_print=True)
+        else:
+            content = content.replace(">", ">BREAKLINESTAGS")
+            content = content.replace("<", "BREAKLINESTAGS<")
+            items = []
+            for item in content.split("BREAKLINESTAGS"):
+                if item.startswith("</"):
+                    items.append(item)
+                elif item.endswith(">"):
+                    items.append("\n" + item)
+                else:
+                    items.append(item)
+            content = "".join(items).strip()
+    return content
 
-    def __init__(self, content):
-        self.content = self.break_in_lines(content)
-        self.tree, self.loading_error = load_xml(self.content)
 
-    def break_in_lines(self, content):
-        """
-        Modifica o conteúdo XML em várias linhas para que ao ser validado fique
-        fácil de localizar o erro pelo número da linha
-        """
-        if content:
-            xml, error = load_xml(content, remove_blank_text=True)
-            if xml:
-                content = tostring(xml, pretty_print=True)
-            else:
-                content = content.replace(">", ">BREAKLINESTAGS")
-                content = content.replace("<", "BREAKLINESTAGS<")
-                items = []
-                for item in content.split("BREAKLINESTAGS"):
-                    if item.startswith("</"):
-                        items.append(item)
-                    elif item.endswith(">"):
-                        items.append("\n" + item)
-                    else:
-                        items.append(item)
-                content = "".join(items).strip()
-        return content
-
-    @property
-    def numbered_lines(self):
-        return "\n".join([
-            '{}: {}'.format(number, msg)
-            for number, msg in enumerate(self.content.splitlines(), 1)
-        ])
+def numbered_lines(content):
+    return "\n".join([
+        '{}: {}'.format(number, msg)
+        for number, msg in enumerate(content.splitlines(), 1)
+    ])
 
 
 def get_xml_object(file_path, xml_parser=None):

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -232,6 +232,30 @@ class SuitableXML(object):
                 pretty_print=pretty_print, doctype=doctype)
 
 
+def xml_with_lines_break(content: str) -> str:
+    """
+    Retorna o conteúdo XML em várias linhas para que ao ser validado fique 
+    fácil de localizar o erro pelo número da linha
+    """
+    if content:
+        xml, error = load_xml(content, remove_blank_text=True)
+        if xml:
+            content = tostring(xml, pretty_print=True)
+        else:
+            content = content.replace(">", ">BREAKLINESTAGS")
+            content = content.replace("<", "BREAKLINESTAGS<")
+            items = []
+            for item in content.split("BREAKLINESTAGS"):
+                if item.startswith("</"):
+                    items.append(item)
+                elif item.endswith(">"):
+                    items.append("\n" + item)
+                else:
+                    items.append(item)
+            content = "".join(items).strip()
+    return content
+
+
 def get_xml_object(file_path, xml_parser=None):
     """
     Modo simplificado para carregar uma árvore de XML dado um arquivo

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -261,6 +261,13 @@ class XMLinMultipleLines(object):
                 content = "".join(items).strip()
         return content
 
+    @property
+    def numbered_lines(self):
+        return "\n".join([
+            '{}: {}'.format(number, msg)
+            for number, msg in enumerate(self.content.splitlines(), 1)
+        ])
+
 
 def get_xml_object(file_path, xml_parser=None):
     """

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -232,28 +232,34 @@ class SuitableXML(object):
                 pretty_print=pretty_print, doctype=doctype)
 
 
-def xml_with_lines_break(content: str) -> str:
-    """
-    Retorna o conteúdo XML em várias linhas para que ao ser validado fique 
-    fácil de localizar o erro pelo número da linha
-    """
-    if content:
-        xml, error = load_xml(content, remove_blank_text=True)
-        if xml:
-            content = tostring(xml, pretty_print=True)
-        else:
-            content = content.replace(">", ">BREAKLINESTAGS")
-            content = content.replace("<", "BREAKLINESTAGS<")
-            items = []
-            for item in content.split("BREAKLINESTAGS"):
-                if item.startswith("</"):
-                    items.append(item)
-                elif item.endswith(">"):
-                    items.append("\n" + item)
-                else:
-                    items.append(item)
-            content = "".join(items).strip()
-    return content
+class XMLinMultipleLines(object):
+
+    def __init__(self, content):
+        self.content = self.break_in_lines(content)
+        self.tree, self.loading_error = load_xml(self.content)
+
+    def break_in_lines(self, content):
+        """
+        Modifica o conteúdo XML em várias linhas para que ao ser validado fique
+        fácil de localizar o erro pelo número da linha
+        """
+        if content:
+            xml, error = load_xml(content, remove_blank_text=True)
+            if xml:
+                content = tostring(xml, pretty_print=True)
+            else:
+                content = content.replace(">", ">BREAKLINESTAGS")
+                content = content.replace("<", "BREAKLINESTAGS<")
+                items = []
+                for item in content.split("BREAKLINESTAGS"):
+                    if item.startswith("</"):
+                        items.append(item)
+                    elif item.endswith(">"):
+                        items.append("\n" + item)
+                    else:
+                        items.append(item)
+                content = "".join(items).strip()
+        return content
 
 
 def get_xml_object(file_path, xml_parser=None):

--- a/src/scielo/bin/xml/prodtools/validations/pkg_articles_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/pkg_articles_validations.py
@@ -15,7 +15,6 @@ class PkgArticlesValidationsReports(object):
                  is_xml_generation, config):
         self.consistency_validations = None
         self.is_db_generation = is_db_generation
-        self.merged_articles_reports = None
         pkg_validator = PackageValidator(
             registered_issue_data, pkg, is_xml_generation, config)
         self.pkg_articles_validations = pkg_validator.validate_package()

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -127,9 +127,9 @@ class PackToolsXMLValidator(object):
         self.tree, self.loading_error = xml_utils.load_xml(content)
         if self.loading_error:
             self.loading_error = (
-                self.file_path +
-                self.loading_error +
-                "\n" + xml_utils.numbered_lines(content)
+                self.file_path + "\n\n" +
+                self.loading_error + "\n\n" +
+                xml_utils.numbered_lines(content)
             )
             fs_utils.write_file(self.file_path, content)
 

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -123,9 +123,14 @@ class PackToolsXMLValidator(object):
 
     def load_xml(self):
         content = fs_utils.read_file(self.file_path)
-        content = xml_utils.xml_with_lines_break(content)
+        content = xml_utils.insert_break_lines(content)
         self.tree, self.loading_error = xml_utils.load_xml(content)
         if self.loading_error:
+            self.loading_error = (
+                self.file_path +
+                self.loading_error +
+                "\n" + xml_utils.numbered_lines(content)
+            )
             fs_utils.write_file(self.file_path, content)
 
     def validate_doctype(self):
@@ -173,7 +178,7 @@ class PackToolsXMLValidator(object):
         dtd_is_valid = False
         dtd_errors = []
         if self.loading_error:
-            dtd_errors += [self.loading_error]
+            dtd_errors = [self.loading_error]
             return dtd_is_valid, dtd_errors
 
         try:

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -159,6 +159,53 @@ class TestLoadXML(TestCase):
             "line 1, column 14 (<string>, line 1)")
 
 
+class TestXMLInMultiplesLines(TestCase):
+
+    def test_xml_with_lines_break_uses_pretty_print(self):
+        text = (
+            "<root>"
+            "<p>Texto 1 "
+            "<bold>bold</bold> texto 2, "
+            "<italic>texto italic</italic> "
+            "<italic>outro italic</italic></p></root>"
+            )
+        expected = (
+            "<root>"
+            "\n  "
+            "<p>Texto 1 "
+            "<bold>bold</bold> texto 2, "
+            "<italic>texto italic</italic> "
+            "<italic>outro italic</italic></p>"
+            "\n"
+            "</root>"
+            "\n"
+            )
+        text_in_multiple_lines = xml_utils.xml_with_lines_break(text)
+        self.assertEqual(expected, text_in_multiple_lines)
+
+    def test_xml_with_lines_break_uses_str_replace(self):
+        text = (
+            "<root>"
+            "<p>Texto 1 "
+            "<bold>bold</bold> texto 2, "
+            "<italic>texto italic</italic> "
+            "<italic>outro italic</italic></root>"
+            )
+        expected = (
+            "<root>"
+            "\n"
+            "<p>Texto 1 "
+            "\n"
+            "<bold>bold</bold> texto 2, "
+            "\n"
+            "<italic>texto italic</italic> "
+            "\n"
+            "<italic>outro italic</italic></root>"
+            )
+        text_in_multiple_lines = xml_utils.xml_with_lines_break(text)
+        self.assertEqual(expected, text_in_multiple_lines)
+
+
 class TestRemoveStylesTags(TestCase):
 
     def test_remove_styles_off_tagged_content_removes_italic(self):

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -207,6 +207,25 @@ class TestXMLinMultipleLines(TestCase):
         content = obj.break_in_lines(text)
         self.assertEqual(expected, content)
 
+    def test_numbered_lines_prefixes_each_line_with_a_number(self):
+        text = (
+            "<root>"
+            "<p>Texto 1 "
+            "<bold>bold</bold> texto 2, "
+            "<italic>texto italic</italic> "
+            "<italic>outro italic</italic></root>"
+            )
+        expected = (
+            "1: <root>\n"
+            "2: <p>Texto 1 \n"
+            "3: <bold>bold</bold> texto 2, \n"
+            "4: <italic>texto italic</italic> \n"
+            "5: <italic>outro italic</italic></root>"
+            )
+        obj = xml_utils.XMLinMultipleLines(text)
+        content = obj.numbered_lines
+        self.assertEqual(expected, content)
+
 
 class TestRemoveStylesTags(TestCase):
 

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -161,7 +161,7 @@ class TestLoadXML(TestCase):
 
 class TestXMLinMultipleLines(TestCase):
 
-    def test_xml_with_lines_break_uses_pretty_print(self):
+    def test_insert_break_lines_uses_pretty_print(self):
         text = (
             "<root>"
             "<p>Texto 1 "
@@ -180,11 +180,10 @@ class TestXMLinMultipleLines(TestCase):
             "</root>"
             "\n"
             )
-        obj = xml_utils.XMLinMultipleLines(text)
-        content = obj.break_in_lines(text)
+        content = xml_utils.insert_break_lines(text)
         self.assertEqual(expected, content)
 
-    def test_xml_with_lines_break_uses_str_replace(self):
+    def test_insert_break_lines_uses_str_replace(self):
         text = (
             "<root>"
             "<p>Texto 1 "
@@ -203,16 +202,15 @@ class TestXMLinMultipleLines(TestCase):
             "\n"
             "<italic>outro italic</italic></root>"
             )
-        obj = xml_utils.XMLinMultipleLines(text)
-        content = obj.break_in_lines(text)
+        content = xml_utils.insert_break_lines(text)
         self.assertEqual(expected, content)
 
     def test_numbered_lines_prefixes_each_line_with_a_number(self):
         text = (
-            "<root>"
-            "<p>Texto 1 "
-            "<bold>bold</bold> texto 2, "
-            "<italic>texto italic</italic> "
+            "<root>\n"
+            "<p>Texto 1 \n"
+            "<bold>bold</bold> texto 2, \n"
+            "<italic>texto italic</italic> \n"
             "<italic>outro italic</italic></root>"
             )
         expected = (
@@ -222,8 +220,7 @@ class TestXMLinMultipleLines(TestCase):
             "4: <italic>texto italic</italic> \n"
             "5: <italic>outro italic</italic></root>"
             )
-        obj = xml_utils.XMLinMultipleLines(text)
-        content = obj.numbered_lines
+        content = xml_utils.numbered_lines(text)
         self.assertEqual(expected, content)
 
 

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -159,7 +159,7 @@ class TestLoadXML(TestCase):
             "line 1, column 14 (<string>, line 1)")
 
 
-class TestXMLInMultiplesLines(TestCase):
+class TestXMLinMultipleLines(TestCase):
 
     def test_xml_with_lines_break_uses_pretty_print(self):
         text = (
@@ -180,8 +180,9 @@ class TestXMLInMultiplesLines(TestCase):
             "</root>"
             "\n"
             )
-        text_in_multiple_lines = xml_utils.xml_with_lines_break(text)
-        self.assertEqual(expected, text_in_multiple_lines)
+        obj = xml_utils.XMLinMultipleLines(text)
+        content = obj.break_in_lines(text)
+        self.assertEqual(expected, content)
 
     def test_xml_with_lines_break_uses_str_replace(self):
         text = (
@@ -202,8 +203,9 @@ class TestXMLInMultiplesLines(TestCase):
             "\n"
             "<italic>outro italic</italic></root>"
             )
-        text_in_multiple_lines = xml_utils.xml_with_lines_break(text)
-        self.assertEqual(expected, text_in_multiple_lines)
+        obj = xml_utils.XMLinMultipleLines(text)
+        content = obj.break_in_lines(text)
+        self.assertEqual(expected, content)
 
 
 class TestRemoveStylesTags(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Insere quebra de linhas no XML, especialmente em XMLs quebrados, para que no resultado da validação fique fácil de localizar os erros.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute o comando com um XML quebrado ou um com conteúdo em uma única linha

`python xml_package_maker.py ~/Downloads/1678-9199-jvatitd-26-e20200041.xml`

[1678-9199-jvatitd-26-e20200041.xml 2.zip](https://github.com/scieloorg/PC-Programs/files/4821084/1678-9199-jvatitd-26-e20200041.xml.2.zip)
[2523-3106-adr-60-31.xml 2.zip](https://github.com/scieloorg/PC-Programs/files/4821213/2523-3106-adr-60-31.xml.2.zip)

#### Algum cenário de contexto que queira dar?
Se o XML estiver quebrado, aparecerá a mensagem de erro + o XML com as linhas numeradas.
Se o XML não estiver quebrado, a validação se fará pelo Packtools.


### Screenshots
Não quebrado
<img width="902" alt="Captura de Tela 2020-06-23 às 15 34 25" src="https://user-images.githubusercontent.com/505143/85442997-24177f00-b567-11ea-9b5e-351e752458c9.png">

Quebrado
<img width="1142" alt="Captura de Tela 2020-06-23 às 15 11 40" src="https://user-images.githubusercontent.com/505143/85442555-b9feda00-b566-11ea-8488-7eccdbd328ca.png">


#### Quais são tickets relevantes?
#3247 

### Referências
n/a
