### PR TITLE
Garante que caracteres especiais não sejam convertidos durante a atualização dos PIDs

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/kernel_document.py
+++ b/src/scielo/bin/xml/prodtools/data/kernel_document.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 from lxml import etree  # type: ignore
 
 from prodtools.utils import fs_utils
+from prodtools.utils import xml_utils
 from prodtools.db.pid_versions import PIDVersionsManager
 from . import scielo_id_gen
 
@@ -123,3 +124,14 @@ def add_article_id_to_xml(file_path, pid_and_specific_use_items):
             article_meta.insert(0, article_id)
         new_content = ET.tostring(xml.find(".")).decode("utf-8")
         fs_utils.write_file(file_path, new_content)
+
+
+def write_etree_to_file(tree: etree.ElementTree, path: str) -> None:
+    """Escreve uma árvore lxml em um arquivo de destino. Também
+    garante que as entidades não serão modificadas por meio da função
+    xml_utils.tostring(etree)."""
+
+    if tree is None or path is None:
+        return None
+
+    fs_utils.write_file(path, xml_utils.tostring(tree))

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import tempfile
 import unittest
 from unittest.mock import Mock, patch
 import os
@@ -146,6 +147,24 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             etree.tostring(_tree),
         )
 
+    def test_write_etree_to_file_should_not_update_file_if_etree_is_none(self):
+        temporary_file = tempfile.mktemp()
+        kernel_document.write_etree_to_file(None, path=temporary_file)
+        self.assertFalse(os.path.exists(temporary_file))
+
+    def test_write_etree_to_file_should_not_convert_character_to_entity(self):
+        tree = etree.fromstring(
+            """<article>
+                <article-meta>
+                    <field>São Paulo - É, ê, È, ç</field>
+                </article-meta>
+            </article>"""
+        )
+        temporary_file = tempfile.mktemp()
+        kernel_document.write_etree_to_file(tree, path=temporary_file)
+
+        with open(temporary_file, "r") as f:
+            self.assertIn("São Paulo - É, ê, È, ç", f.read())
 
 class TestKernelDocument(unittest.TestCase):
     """docstring for TestKernelDocument"""

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -84,8 +84,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
                     self.assertIn('specific-use="scielo-v2"', content)
                     self.assertIn(expected_scielo_id, content)
 
-    @patch("prodtools.data.kernel_document.add_article_id_to_xml")
-    def test_pid_manager_should_use_aop_pid_to_search_pid_v3_from_database(self, _):
+    def test_pid_manager_should_use_aop_pid_to_search_pid_v3_from_database(self,):
         def _update_article_with_aop_pid(article: Article):
             article.registered_aop_pid = "AOPPID"
 
@@ -107,10 +106,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             "pid-v3-registrado-anteriormente-para-documento-aop",
         )
 
-    @patch("prodtools.data.kernel_document.add_article_id_to_xml")
-    def test_pid_manager_does_not_register_pids_if_pid_v3_already_exists_in_xml(
-        self, mock
-    ):
+    def test_pid_manager_does_not_register_pids_if_pid_v3_already_exists_in_xml(self):
 
         mock_pid_manager = Mock()
 
@@ -165,6 +161,21 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
 
         with open(temporary_file, "r") as f:
             self.assertIn("São Paulo - É, ê, È, ç", f.read())
+
+    @patch("prodtools.data.kernel_document.write_etree_to_file")
+    def test_should_call_the_write_etree_to_file_when_the_pid_list_isnt_empty(self, mk):
+        kernel_document.add_article_id_to_received_documents(
+            pid_manager=Mock(),
+            issn_id="9876-3456",
+            year_and_order="20173",
+            received_docs={"file1": Article("pid-v3", None)},
+            documents_in_isis={},
+            file_paths={"file1": "file1.xml"},
+            update_article_with_aop_status=lambda _: _,
+        )
+
+        mk.assert_called_once()
+
 
 class TestKernelDocument(unittest.TestCase):
     """docstring for TestKernelDocument"""

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -186,6 +186,16 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
         with open(temporary_file, "r") as f:
             self.assertIn("São Paulo - É, ê, È, ç", f.read())
 
+    def test_write_etree_to_file_should_not_change_the_document_doctype(self):
+        temporary_file = tempfile.mktemp()
+        kernel_document.write_etree_to_file(self.tree, path=temporary_file)
+
+        with open(temporary_file, "r") as f:
+            self.assertIn(
+                """<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">""",
+                f.read(),
+            )
+
     @patch("prodtools.data.kernel_document.write_etree_to_file")
     def test_should_call_the_write_etree_to_file_when_the_pid_list_isnt_empty(self, mk):
         kernel_document.add_article_id_to_received_documents(

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import Mock, patch
 import os
 
-from xml.etree import ElementTree as etree
+from lxml import etree
 from copy import deepcopy
 from prodtools.data import kernel_document
 
@@ -124,6 +124,27 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
         )
 
         mock_pid_manager.register.assert_not_called()
+
+    def test_add_pids_to_etree_should_return_none_if_etree_is_not_valid(self):
+        self.assertIsNone(kernel_document.add_article_id_to_etree(None, []))
+
+    def test_add_pids_to_etree_should_not_update_if_pid_list_is_empty(self):
+        tree = etree.fromstring("<article><article-meta></article-meta></article>")
+        self.assertIsNone(kernel_document.add_article_id_to_etree(tree, []))
+
+    def test_add_pids_to_etree_should_etree_with_pid_v3(self):
+        tree = etree.fromstring(
+            """<article>
+                <article-meta></article-meta>
+            </article>"""
+        )
+        _tree = kernel_document.add_article_id_to_etree(
+            tree, [("random-pid", "pid-v3",)]
+        )
+        self.assertIn(
+            b'<article-id specific-use="pid-v3" pub-id-type="publisher-id">random-pid</article-id>',
+            etree.tostring(_tree),
+        )
 
 
 class TestKernelDocument(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request garante que caracteres especiais não sejam modificados ao passo que o XML é modificado com os PIDs v2 e v3.

#### Onde a revisão poderia começar?

- `src/scielo/bin/xml/prodtools/data/kernel_document.py` L: `1`


#### Como este poderia ser testado manualmente?

Para testar este pr manualmente, deve-se:
- Configurar o XC;
- Fazer download do pacote [1];
- Excecute o XC;
- Verifique a saída da pasta `spf` e observe que os caracteres nos XMLs não foram convertidos para entidades.

#### Algum cenário de contexto que queira dar?
Este pr não resolve a questão da localização dos arquivos DTD. Acredito que isso  deve ser feito em um outro local, fora das funções que modificam os pids.

### Screenshots
N/A

#### Quais são tickets relevantes?
#3249 

### Anexos
[[1] - Pacote](https://github.com/scieloorg/PC-Programs/files/4815193/0104-1169-rlae-28-rpass0520.zip)

### Referências
N/A

