### PR TITLE
Corrige quebra do validador do Packtools com conteúdo de XML inválido

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -544,7 +544,7 @@ class SGMLXML2SPSXML(object):
                 )))
         sps_version = xml_obj.find(".").get("sps")
         if sps_version is None:
-            sps_version = xml_versions._SPS_VERSIONS[-1][0][4:]
+            sps_version = xml_versions.get_latest_sps_version()[4:]
             xml_obj.find(".").set("sps", sps_version)
         xsl_filepath = xml_versions.xsl_getter(sps_version)
         result = xml_utils.transform(xml_obj, xsl_filepath)

--- a/src/scielo/bin/xml/prodtools/processing/xml_versions.py
+++ b/src/scielo/bin/xml/prodtools/processing/xml_versions.py
@@ -56,6 +56,10 @@ _SPS_VERSIONS = (
 SPS_VERSIONS = dict(_SPS_VERSIONS)
 
 
+def get_latest_sps_version():
+    return _SPS_VERSIONS[-1][0]
+
+
 def sps_numbers(sps: str) -> tuple:
     if sps and 'sps-' in sps:
         sps = sps[4:]

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -219,8 +219,7 @@ class SuitableXML(object):
               dtd_location_type=None):
         doctype = self.get_doctype(dtd_location_type)
         if self.xml is None:
-            fs_utils.write_file(
-                dest_file_path, self.format(pretty_print, dtd_location_type))
+            fs_utils.write_file(dest_file_path, self.original)
         else:
             self.xml.write(
                 dest_file_path, encoding="utf-8", method="xml",

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -205,16 +205,6 @@ class SuitableXML(object):
                 return self.xml.docinfo.doctype.replace(url, basename)
             return self.xml.docinfo.doctype or None
 
-    def format(self, pretty_print=False, dtd_location_type=None):
-        doctype = self.get_doctype(dtd_location_type)
-        if self.xml is not None:
-            return etree.tostring(
-                self.xml, encoding="utf-8", method="xml",
-                xml_declaration=self.xml_declaration,
-                pretty_print=pretty_print, doctype=doctype
-                ).decode("utf-8")
-        return self.original
-
     def write(self, dest_file_path, pretty_print=True,
               dtd_location_type=None):
         doctype = self.get_doctype(dtd_location_type)

--- a/src/scielo/bin/xml/prodtools/validations/article_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_validations.py
@@ -68,7 +68,7 @@ class XMLIssueDataValidator(object):
 class XMLStructureValidator(object):
     def __init__(self, file_path, xml, sps_version):
         self.validator = sps_xml_validators.PackToolsXMLValidator(
-            file_path, xml, sps_version)
+            file_path, sps_version)
 
     def validate(self, file_path, outputs):
         separator = '\n\n\n' + '.........\n\n\n'

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -111,10 +111,10 @@ class PMCXMLValidator(object):
 
 class PackToolsXMLValidator(object):
 
-    def __init__(self, file_path, tree, sps_version):
+    def __init__(self, file_path, sps_version):
         self.file_path = file_path
         self.load_xml()
-        self.sps_version = sps_version
+        self.sps_version = sps_version or xml_versions.get_latest_sps_version()
 
         self.version = packtools.__version__
 
@@ -182,9 +182,10 @@ class PackToolsXMLValidator(object):
             return dtd_is_valid, dtd_errors
 
         try:
-            logger.info(self.sps_version)
+            logger.info("sps_version: %s", self.sps_version)
             self.xml_validator = packtools.XMLValidator.parse(
-                    self.tree, sps_version=self.sps_version)
+                self.tree, sps_version=self.sps_version
+            )
         except (packtools.etree.XMLSyntaxError, exceptions.XMLDoctypeError,
                 exceptions.XMLSPSVersionError) as e:
             ERR_MESSAGE = ("Validation error of {}: {}.").format(

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -448,13 +448,13 @@ class TestSuitableXML(TestCase):
     def test_init_xml_with_junk_is_loaded_without_errors(self):
         text = "<doc/> lixo"
         suitable_xml = xml_utils.SuitableXML(text)
-        self.assertEqual(suitable_xml.format(), "<doc/>")
+        self.assertEqual(suitable_xml.content, "<doc/>")
         self.assertIsNone(suitable_xml.xml_error)
 
     def test_init_xml_is_ok(self):
         text = "<doc/>"
         suitable_xml = xml_utils.SuitableXML(text)
-        self.assertEqual(suitable_xml.format(), "<doc/>")
+        self.assertEqual(suitable_xml.content, "<doc/>")
         self.assertIsNone(suitable_xml.xml_error)
         self.assertEqual(suitable_xml.doctype, '')
         self.assertIsNone(suitable_xml.xml_declaration)
@@ -472,7 +472,7 @@ class TestSuitableXML(TestCase):
             'Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/'
             'publishing/1.1/JATS-journalpublishing1.dtd">')
         self.assertEqual(
-            suitable_xml.format(),
+            suitable_xml.content,
             '<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal '
             'Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/'
             'publishing/1.1/JATS-journalpublishing1.dtd">\n<article/>')
@@ -495,7 +495,7 @@ class TestSuitableXML(TestCase):
         suitable_xml = xml_utils.SuitableXML(text)
         self.assertEqual(
             expected,
-            suitable_xml.format())
+            suitable_xml.content)
 
     def test_well_formed_xml_content_removes_junk_after_last_close_tag(self):
         text = '<doc><p></p></doc> lixo'


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige quebra do validador do Packtools quando XML é inválido, por não ser possível recuperar a versão SPS do arquivo, e refatora código anterior.

#### Onde a revisão poderia começar?
Indique o caminho do arquivo e o arquivo onde o revisor deve iniciar a leitura do código.

#### Como este poderia ser testado manualmente?
Estabeleça os passos necessários para que a funcionalidade seja testada manualmente pelo revisor.

#### Algum cenário de contexto que queira dar?
Este código foi, a princípio, iniciado para resolver o bug reportado em #3224 mas boa parte dele foi resolvido em PR anterior de formatação do conteúdo XML para exibir no relatório.

### Screenshots
n/a

#### Quais são tickets relevantes?
#3224

### Referências
.