### PR TITLE
Adequa teste para funcionar em todas as versões suportadas do Python

### DIFF
--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -208,7 +208,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             update_article_with_aop_status=lambda _: _,
         )
 
-        mk.assert_called_once()
+        self.assertTrue(mk.called)
 
 
 class TestKernelDocument(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?

Corrige teste do módulo responsável por atribuir pids aos XMLs convertidos pelo XC.

#### Onde a revisão poderia começar?
- `src/scielo/bin/xml/tests/test_kernel_document.py`

#### Como este poderia ser testado manualmente?

Execute os testes automatizados nas versões 3.5, 3.6, 3.7 e 3.8 do Python. Também pode-se observar o status dos testes no Travis-CI

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

