### PR TITLE
Corrige BrokenRef na inserção de label em refs contendo tag e sem texto

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -220,15 +220,19 @@ class BrokenRef(object):
         label = self.tree.find(".//label")
         if label is None:
             return
-        if mixed_citation.text.startswith(label.text):
-            return
         label_text = label.text
-        if label.text[-1] == mixed_citation.text[0]:
-            label_text = label_text[:-1]
         sep = " "
-        if not mixed_citation.text[0].isalnum():
-            sep = ""
-        mixed_citation.text = label_text + sep + mixed_citation.text
+        if mixed_citation.text:
+            _mixed_citation_text = mixed_citation.text
+            if _mixed_citation_text.startswith(label.text):
+                return
+            if label.text[-1] == _mixed_citation_text[0]:
+                label_text = label_text[:-1]
+            if not _mixed_citation_text[0].isalnum():
+                sep = ""
+            mixed_citation.text = label_text + sep + _mixed_citation_text
+        else:
+            mixed_citation.text = label_text + sep
 
     def fix_source(self):
         """

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -180,6 +180,32 @@ class TestBrokenRef(TestCase):
         )
         self.assertEqual(obj.tree.find(".//label").text, "1")
 
+    def test_insert_label_text_in_mixed_citation_text_inserts_1_with_extlink_ref(self):
+        text = (
+            '<ref id="B1">'
+            '<label>1</label>'
+            '<mixed-citation'
+            ' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            ' xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<ext-link ext-link-type="uri" xlink:href="https://linkdainternet.net/texto.pdf">'
+            'https://linkdainternet.net/texto.pdf</ext-link>'
+            ', acessada em Abril 2020. <italic>Nome do Site</italic></mixed-citation>'
+            '</ref>'
+            )
+        xml = xml_utils.etree.fromstring(text)
+        obj = sps_pkgmaker.BrokenRef(xml)
+        obj.insert_label_text_in_mixed_citation_text()
+        self.assertEqual(
+            xml_utils.etree.tostring(obj.tree.find(".//mixed-citation")),
+            b'<mixed-citation'
+            b' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b'1 <ext-link ext-link-type="uri" xlink:href="https://linkdainternet.net/texto.pdf">'
+            b'https://linkdainternet.net/texto.pdf</ext-link>'
+            b', acessada em Abril 2020. <italic>Nome do Site</italic></mixed-citation>'
+        )
+        self.assertEqual(obj.tree.find(".//label").text, "1")
+
 
 class TestBrokenRefFixBookData(TestCase):
     def test_fix_book_data_does_not_convert_article_title_into_chapter_title(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR resolve a exceção que ocorre quando a `mixed-citation` não tem texto mas tag. Caso não tenha o texto, insere o texto do label, da mesma forma como é feito para os casos onde há o texto e o label é inserido antes.

#### Onde a revisão poderia começar?
Commit https://github.com/scieloorg/PC-Programs/commit/d696447891bded3609ac4635cb987c10cb444a72

#### Como este poderia ser testado manualmente?
Com XML contendo alguma `mixed-citation` onde a referência citada inicia-se com um link externo ou qualquer outra tag:
- Execute o comando `scieloxpm <caminho para o XML>`
- A aplicação deve conseguir gerar o pacote sem quebrar
- Todas as mixed-citations devem ter sido geradas com seus respectivos labels nos XMLs.

#### Algum cenário de contexto que queira dar?
Este erro foi identificado durante os testes do XC Server no ambiente de testes para o SPF.

### Screenshots

XML convertido após correção

<img width="1327" alt="Screen Shot 2020-06-29 at 09 46 46" src="https://user-images.githubusercontent.com/18053487/86034416-f328c580-ba10-11ea-970a-57c2f58ad68e.png">


#### Quais são tickets relevantes?
#3259 

### Referências
Possíveis conteúdos de `mixed-citation`: https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/mixed-citation.html