### PR TITLE
Se o `*.sgm.xml` está quebrado não interromper o programa e informa que está quebrado no relatório

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -578,7 +578,7 @@ class SGMLXML2SPSXML(object):
         content = xml_utils.insert_namespaces_in_root("article", str(result))
         fs_utils.write_file(self.FILES.src_pkgfiles.filename, content)
 
-    def _make_package(self):
+    def _name_package(self):
         """
         Copia os arquivos da pasta src e o da pasta temporária do pacote
         individual scielo_package
@@ -588,6 +588,8 @@ class SGMLXML2SPSXML(object):
         self.pkg_namer = PackageNamer(self.FILES.src_pkgfiles, self.acron,
                                       self.FILES.tmp_doc_pkg_path)
         self.pkg_namer.rename()
+
+    def _make_package(self):
         """
         cria o pacote otimizado na pasta individual
         markup_xml/work/sgmxml_name/scielo_package
@@ -622,14 +624,12 @@ class SGMLXML2SPSXML(object):
             """
             self._sgmxml()
             self._sgmxml2xml()
+            self._name_package()
             pkg = self._make_package()
         except Exception as e:
             blocking_error = str(e)
             logger.exception(e)
-            raise e
-
         finally:
-            logger.info("Create Images Report")
             self._report(blocking_error, pkg)
         return pkg
 
@@ -642,6 +642,7 @@ class ImagesOriginReport(object):
         self.images_origin = images_origin
 
     def report(self):
+        logger.info("Create Images Report")
         rows = []
         if len(self.href_replacements) == 0:
             rows.append(html_reports.tag('h4', _('Article has no image')))

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -238,6 +238,10 @@ def insert_break_lines(content):
                 else:
                     items.append(item)
             content = "".join(items).strip()
+
+            if not content.startswith("<") and ord(content[0]) == 65279:
+                # unexpected whitespace character unicode 65279 (utf-8 bom)
+                content = content[1:].strip()
     return content
 
 

--- a/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
+++ b/src/scielo/bin/xml/prodtools/validations/sps_xml_validators.py
@@ -126,10 +126,13 @@ class PackToolsXMLValidator(object):
         content = xml_utils.insert_break_lines(content)
         self.tree, self.loading_error = xml_utils.load_xml(content)
         if self.loading_error:
+            content = xml_utils.numbered_lines(content)
+            if content.startswith("1: <?xml"):
+                content = content[content.find("?>")+2:].strip()
             self.loading_error = (
                 self.file_path + "\n\n" +
                 self.loading_error + "\n\n" +
-                xml_utils.numbered_lines(content)
+                content
             )
             fs_utils.write_file(self.file_path, content)
 


### PR DESCRIPTION
#### O que esse PR faz?
Trata quando o `*.sgm.xml` está quebrado sem interromper o programa

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Abrir um arquivo `*.docx` que esteja com a marcação quebrada (há um em anexos)
Clicar em "Gerar XML"
Ao finalizar apresentará o relatório com o sgml quebrado.

#### Algum cenário de contexto que queira dar?
foi necessário remover do relatório a declaração do XML: `<?xml version="1.0" encoding="utf-8"?>` porque o relatório não abria automaticamente no Word.

### Screenshots
<img width="1193" alt="Captura de Tela 2020-06-30 às 10 08 41" src="https://user-images.githubusercontent.com/505143/86130355-69cdcd80-baba-11ea-95fe-3b472b8de5f3.png">


#### Quais são tickets relevantes?
#3265

### Referências
n/a

