### PR TITLE
Corrige a condição de existência de fpage ao gerar o XML a partir do Markup

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -106,8 +106,11 @@ class PackageName(object):
         parts = [self.issn, acron, self.doc.volume, self.issueno, self.suppl, self.last, self.doc.compl]
         return '-'.join([part for part in parts if part])
 
-    def zero(self, value):
-        return value and value.isdigit() and int(value) == 0
+    def zero(self, value: str) -> bool:
+        """
+        Retorna True se value representa 0 ou 00 ou 000...
+        """
+        return bool(value) and value.isdigit() and int(value) == 0
 
     @property
     def issueno(self):

--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -135,7 +135,7 @@ class PackageName(object):
 
     @property
     def last(self):
-        if not self.zero(self.doc.fpage):
+        if self.doc.fpage and not self.zero(self.doc.fpage):
             return self.doc.fpage + (self.doc.fpage_seq or "")
         if self.doc.elocation_id:
             return self.doc.elocation_id


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a condição de existência de fpage ao gerar o XML a partir do Markup. Desta forma, o programa termina adequadamente.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Abrir o arquivo marcado em anexo no markup e clicar em Gerar XML.
[187-4150-1-PB.docx](https://github.com/scieloorg/PC-Programs/files/4852810/187-4150-1-PB.docx)
Ou executar o comando informado no issue relacionado

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3264

### Referências
n/a
