### PR TITLE
Corrige a geração do conteúdo de `<history>`, não criar `<date date-type="bold"/>`

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
+++ b/src/scielo/bin/xml/prodtools/processing/sgmlxml.py
@@ -135,7 +135,7 @@ class PackageName(object):
 
     @property
     def last(self):
-        if not self.zero(self.doc.fpage):
+        if self.doc.fpage and not self.zero(self.doc.fpage):
             return self.doc.fpage + (self.doc.fpage_seq or "")
         if self.doc.elocation_id:
             return self.doc.elocation_id

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1519,8 +1519,8 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 	</xsl:template>
 	<xsl:template match="hist/*">
 		<xsl:if test="@datetype or @dateiso">
-			
-		<xsl:variable name="dtype">
+		<date>
+			<xsl:attribute name="date-type">
 			<xsl:choose>
 				<xsl:when test="name()='revised'">rev-recd</xsl:when>
 				<xsl:when test="@datetype!=''">
@@ -1530,9 +1530,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 					<xsl:value-of select="name()"/>
 				</xsl:when>
 			</xsl:choose>
-		</xsl:variable>
-		<date>
-			<xsl:attribute name="date-type"><xsl:value-of select="$datetype"/></xsl:attribute>
+			</xsl:attribute>
 			<xsl:call-template name="display_date">
 				<xsl:with-param name="dateiso">
 					<xsl:value-of select="@dateiso"/>

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1519,24 +1519,24 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 	</xsl:template>
 	<xsl:template match="hist/*">
 		<xsl:if test="@datetype or @dateiso">
-		<date>
-			<xsl:attribute name="date-type">
-			<xsl:choose>
-				<xsl:when test="name()='revised'">rev-recd</xsl:when>
-				<xsl:when test="@datetype!=''">
-					<xsl:value-of select="@datetype"/>
-				</xsl:when>
-				<xsl:when test="@dateiso">
-					<xsl:value-of select="name()"/>
-				</xsl:when>
-			</xsl:choose>
-			</xsl:attribute>
-			<xsl:call-template name="display_date">
-				<xsl:with-param name="dateiso">
-					<xsl:value-of select="@dateiso"/>
-				</xsl:with-param>
-			</xsl:call-template>
-		</date>
+			<date>
+				<xsl:attribute name="date-type">
+					<xsl:choose>
+						<xsl:when test="name()='revised'">rev-recd</xsl:when>
+						<xsl:when test="@datetype!=''">
+							<xsl:value-of select="@datetype"/>
+						</xsl:when>
+						<xsl:when test="@dateiso">
+							<xsl:value-of select="name()"/>
+						</xsl:when>
+					</xsl:choose>
+				</xsl:attribute>
+				<xsl:call-template name="display_date">
+					<xsl:with-param name="dateiso">
+						<xsl:value-of select="@dateiso"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</date>
 		</xsl:if>
 	</xsl:template>
 	

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1524,9 +1524,9 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				<xsl:when test="@datetype!=''">
 					<xsl:value-of select="@datetype"/>
 				</xsl:when>
-				<xsl:otherwise>
+				<xsl:when test="@dateiso">
 					<xsl:value-of select="name()"/>
-				</xsl:otherwise>
+				</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
 		<date date-type="{$dtype}">

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1529,6 +1529,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
+		<xsl:if test="$dtype!=''">
 		<date date-type="{$dtype}">
 			<xsl:call-template name="display_date">
 				<xsl:with-param name="dateiso">
@@ -1536,6 +1537,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				</xsl:with-param>
 			</xsl:call-template>
 		</date>
+		</xsl:if>
 	</xsl:template>
 	
 	<xsl:template match="abstract|xmlabstr">

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1518,6 +1518,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 		</history>
 	</xsl:template>
 	<xsl:template match="hist/*">
+		<xsl:if test="@datetype or @dateiso">
 		<xsl:variable name="dtype">
 			<xsl:choose>
 				<xsl:when test="name()='revised'">rev-recd</xsl:when>
@@ -1529,7 +1530,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
-		<xsl:if test="$dtype!=''">
+		
 		<date date-type="{$dtype}">
 			<xsl:call-template name="display_date">
 				<xsl:with-param name="dateiso">

--- a/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
+++ b/src/scielo/bin/xml/prodtools/settings/dtd_and_xsl/v3.0/xsl/sgml2xml/sgml2generic.xsl
@@ -1519,6 +1519,7 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 	</xsl:template>
 	<xsl:template match="hist/*">
 		<xsl:if test="@datetype or @dateiso">
+			
 		<xsl:variable name="dtype">
 			<xsl:choose>
 				<xsl:when test="name()='revised'">rev-recd</xsl:when>
@@ -1530,8 +1531,8 @@ xmlns:ie5="http://www.w3.org/TR/WD-xsl"
 				</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
-		
-		<date date-type="{$dtype}">
+		<date>
+			<xsl:attribute name="date-type"><xsl:value-of select="$datetype"/></xsl:attribute>
 			<xsl:call-template name="display_date">
 				<xsl:with-param name="dateiso">
 					<xsl:value-of select="@dateiso"/>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a geração do conteúdo de `<history>`, não criar `<date date-type="bold"/>`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Da mesma forma como indicado em "reproduzir" o erro.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3270 

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.3d1/element/history.html
