### PR TITLE
Corrige acesso a elementos de `contrib` ao gerar relatório de validação

### DIFF
--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -489,9 +489,19 @@ class ArticleContentValidation(object):
         for doc, contribs in self.article.doc_and_contribs_items:
             msgs = self.validate_contrib_item(doc, contribs)
             for msg in msgs or []:
-                r.append(
-                    ('contrib', validation_status.STATUS_FATAL_ERROR, msg,
-                        xml_utils.tostring(contribs[0].getparent())))
+                if contribs is not None and len(contribs) > 0:
+                    r.append(
+                        (
+                            "contrib",
+                            validation_status.STATUS_FATAL_ERROR,
+                            msg,
+                            xml_utils.tostring(contribs[0].getparent()),
+                        )
+                    )
+                else:
+                    r.append(
+                        ("contrib", validation_status.STATUS_FATAL_ERROR, msg, "",)
+                    )
         return r
 
     @property


### PR DESCRIPTION
## O que esse PR faz?
Durante o uso da propriedade `contrib` presente nas validações de XMLs é possível é necessário verificar a possibilidade de encontrar o elemento pai para ai anexar sua representação xml ao relatório.

#### Onde a revisão poderia começar?

- `src/scielo/bin/xml/prodtools/validations/article_content_validations.py` L: `493`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Utilize o pacote `1806-9282-ramb-66-05.zip` presente no `dsteste`;
- Execute o XC;
- Verifique que o Programa não quebra;
- Verifique que o relatório do documento `1806-9282-ramb-66-5-0707` indica a necessidade da inserção dos elementos de `contrib`;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#3261

### Referências
N/A

