### PR TITLE
Converte método da classe Configuration em propriedade seguindo padrão utilizado

### DIFF
--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -279,6 +279,7 @@ class Configuration(object):
     def email_to(self):
         return self._data.get('EMAIL_TO')
 
+    @property
     def email_subject_conversion_failure(self):
         return self._data.get('EMAIL_SUBJECT_CONVERSION_FAILURE')
 

--- a/src/scielo/bin/xml/tests/test_xc_configuration.py
+++ b/src/scielo/bin/xml/tests/test_xc_configuration.py
@@ -1,0 +1,23 @@
+import unittest
+
+from prodtools.config.config import Configuration
+
+
+class TestConfigurationOfXC(unittest.TestCase):
+    def setUp(self):
+        self.configuration = Configuration()
+        self.configuration._data = {
+            "EMAIL_SUBJECT_CONVERSION_FAILURE": "Conversion Failure"
+        }
+
+    def test_email_subject_conversion_failure_should_exists_if_config_has_the_related_key(
+        self,
+    ):
+        self.assertIsNotNone(self.configuration.email_subject_conversion_failure)
+        self.assertEqual(
+            self.configuration.email_subject_conversion_failure, "Conversion Failure"
+        )
+
+    def test_email_subject_conversion_failure_returns_none_if_config_is_empty(self):
+        self.configuration._data = {}
+        self.assertIsNone(self.configuration.email_subject_conversion_failure)


### PR DESCRIPTION
### O que esse PR faz?

Corrige a issue #3275 para que os e-mails que reportam falhas cheguem com o devido assunto.

#### Onde a revisão poderia começar?

- `src/scielo/bin/xml/prodtools/config/config.py`

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente, deve-se:
- Ativar o envio de e-mail pelo XC;
- Configure a variável `EMAIL_SUBJECT_CONVERSION_FAILURE`;
- Executar o XC com um pacote quebrado;
- Verificar o e-mail recebido com o assunto configurado na variável `EMAIL_SUBJECT_CONVERSION_FAILURE`;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#3275

### Referências
N/A

