### PR TITLE
Acrescenta addendum a lista de related-article-type e também acrescenta validações e correções

### DIFF
--- a/src/scielo/bin/markup/app_core/attb.mds
+++ b/src/scielo/bin/markup/app_core/attb.mds
@@ -51,8 +51,8 @@ norgname
 
 
 reltp
-peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
-peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
+addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
+addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
 
 pid-doi
 

--- a/src/scielo/bin/markup/app_core/attb.mds
+++ b/src/scielo/bin/markup/app_core/attb.mds
@@ -51,8 +51,8 @@ norgname
 
 
 reltp
-addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
-addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-article;retracted-article
+addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-retraction;retracted-article
+addendum;peer-reviewed-material;referee-report;press-release;article;commentary-article;corrected-article;letter;partial-retraction;retracted-article
 
 pid-doi
 

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -775,6 +775,25 @@ class ArticleXML(object):
         return r
 
     @property
+    def related_objects(self):
+        r = []
+        if self.article_meta is not None:
+            related = self.article_meta.findall('related-object')
+            for rel in related:
+                item = {}
+                item['href'] = rel.attrib.get('{http://www.w3.org/1999/xlink}href')
+                item['related-object-type'] = rel.attrib.get('related-object-type')
+                item['ext-link-type'] = rel.attrib.get('ext-link-type')
+                if item['ext-link-type'] == 'scielo-pid':
+                    item['ext-link-type'] = 'pid'
+                item['id'] = rel.attrib.get('id')
+                if item['related-object-type'] not in attributes.related_objects_type:
+                    item['id'] = ''.join([c for c in item['id'] if c.isdigit()])
+                item['xml'] = tostring(rel)
+                r.append(item)
+        return r
+
+    @property
     def journal_title(self):
         if self.journal_meta is not None:
             return self.journal_meta.findtext('.//journal-title')

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -787,8 +787,6 @@ class ArticleXML(object):
                 if item['ext-link-type'] == 'scielo-pid':
                     item['ext-link-type'] = 'pid'
                 item['id'] = rel.attrib.get('id')
-                if item['related-object-type'] not in attributes.related_objects_type:
-                    item['id'] = ''.join([c for c in item['id'] if c.isdigit()])
                 item['xml'] = tostring(rel)
                 r.append(item)
         return r

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -273,7 +273,9 @@ related_articles_type = [
     'addendum',
     'corrected-article',
     'commentary-article',
-    'press-release',
+    'retracted-article',
+    'letter',
+    'partial-retraction',
     'retracted-article',
 ]
 

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -269,7 +269,12 @@ COUNTRY_CODES = [
 
 PERMISSION_ELEMENTS = ['license', 'copyright-holder', 'copyright-year', 'copyright-statement']
 
-related_articles_type = ['corrected-article', 'commentary-article', 'press-release', 'retracted-article']
+related_articles_type = [
+    'corrected-article',
+    'commentary-article',
+    'press-release',
+    'retracted-article',
+]
 
 CONTRIB_ID_URLS = {
     'lattes': 'https://lattes.cnpq.br/',

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -99,6 +99,7 @@ INDEXABLE_WITH_FLEXIBLE_REQUIREMENTS = {
 }
 
 INDEXABLE_AND_DONT_REQUIRE_CONTRIB_AFF_XREF_REF = [
+    'addendum',
     'correction',
     'retraction',
     'partial-retraction',

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -270,6 +270,7 @@ COUNTRY_CODES = [
 PERMISSION_ELEMENTS = ['license', 'copyright-holder', 'copyright-year', 'copyright-statement']
 
 related_articles_type = [
+    'addendum',
     'corrected-article',
     'commentary-article',
     'press-release',

--- a/src/scielo/bin/xml/prodtools/data/attributes.py
+++ b/src/scielo/bin/xml/prodtools/data/attributes.py
@@ -279,6 +279,11 @@ related_articles_type = [
     'retracted-article',
 ]
 
+related_objects_type = [
+    'referee-report',
+    'peer-reviewed-material',
+]
+
 CONTRIB_ID_URLS = {
     'lattes': 'https://lattes.cnpq.br/',
     'orcid': 'https://orcid.org/',

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -421,13 +421,14 @@ class ArticleContentValidation(object):
             expected_values = attributes.related_objects_type
             msg = data_validations.is_expected_value('related-object/@related-object-type', value, expected_values, validation_status.STATUS_FATAL_ERROR)
             r.append(msg)
-            if related.get('ext-link-type', '') == 'doi':
-                _doi = related.get('href', '')
-                if _doi != '':
+            if related.get('ext-link-type') == 'doi':
+                valid = False
+                _doi = related.get('href')
+                if _doi:
                     valid = self.doi_validator.validate_format(_doi)
-                    if not valid:
-                        msg = data_validations.invalid_value_message('related-object/@xlink:href', related.get('href'))
-                        r.append(('related-object/@xlink:href', validation_status.STATUS_FATAL_ERROR, msg + ('The content of {label} must be a DOI number. ').format(label='related-object/@xlink:href')))
+                if not valid:
+                    msg = data_validations.invalid_value_message('related-object/@xlink:href', related.get('href'))
+                    r.append(('related-object/@xlink:href', validation_status.STATUS_FATAL_ERROR, msg + ('The content of {label} must be a DOI number. ').format(label='related-object/@xlink:href')))
         return r
 
     @property

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -404,6 +404,32 @@ class ArticleContentValidation(object):
         return r
 
     @property
+    def related_objects(self):
+        """
+        @id k
+        @xlink:href i
+        @ext-link-type n
+        . t article
+        @related-object-type
+        @id k
+        . t pr
+        """
+        r = []
+        for related in self.article.related_objects:
+            value = related.get('related-object-type')
+            expected_values = attributes.related_objects_type
+            msg = data_validations.is_expected_value('related-object/@related-object-type', value, expected_values, validation_status.STATUS_FATAL_ERROR)
+            r.append(msg)
+            if related.get('ext-link-type', '') == 'doi':
+                _doi = related.get('href', '')
+                if _doi != '':
+                    valid = self.doi_validator.validate_format(_doi)
+                    if not valid:
+                        msg = data_validations.invalid_value_message('related-object/@xlink:href', related.get('href'))
+                        r.append(('related-object/@xlink:href', validation_status.STATUS_FATAL_ERROR, msg + ('The content of {label} must be a DOI number. ').format(label='related-object/@xlink:href')))
+        return r
+
+    @property
     def refstats(self):
         r = []
         non_scholar_types = [k for k in self.article.refstats.keys() if k not in attributes.BIBLIOMETRICS_USE]

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -217,6 +217,7 @@ class ArticleContentValidation(object):
                     self.history,
                     self.titles_abstracts_keywords,
                     self.related_articles,
+                    self.related_objects,
                 ])
 
             items.extend([

--- a/src/scielo/bin/xml/tests/test_article_content_validations.py
+++ b/src/scielo/bin/xml/tests/test_article_content_validations.py
@@ -88,7 +88,7 @@ class TestArticleContentValidation(TestCase):
             result,
             ['contrib[2] in DUMMY must have "role"'])
 
-    def test_contrib_validation_should_not_display_the_element_tree_when_parent_element_is_empty(
+    def test_contrib_validation_returns_empty_list_because_it_is_not_required_contrib_for_addendum(
         self,
     ):
         text = """<article 
@@ -114,12 +114,4 @@ class TestArticleContentValidation(TestCase):
             config=Mock(),
         )
 
-        expected = [
-            (
-                "contrib",
-                "[FATAL ERROR]",
-                "article requires contrib names or collabs. ",
-                "",
-            )
-        ]
-        self.assertEqual(content_validation.contrib, expected)
+        self.assertEqual(content_validation.contrib, [])

--- a/src/scielo/bin/xml/tests/test_article_content_validations.py
+++ b/src/scielo/bin/xml/tests/test_article_content_validations.py
@@ -6,6 +6,9 @@ from lxml import etree
 from prodtools.validations.article_content_validations import (
     ArticleContentValidation
 )
+from prodtools.data.article import (
+    Article
+)
 
 
 class TestArticleContentValidation(TestCase):
@@ -115,3 +118,138 @@ class TestArticleContentValidation(TestCase):
         )
 
         self.assertEqual(content_validation.contrib, [])
+
+
+class TestArticleContentValidationRelatedObjects(TestCase):
+
+    def get_article_content_validations(self, xml):
+        return ArticleContentValidation(
+            journal=Mock(),
+            _article=Article(xml, 'xml_name'),
+            pkgfiles=Mock(),
+            is_db_generation=Mock(),
+            check_url=Mock(),
+            doi_validator=Mock(),
+            config=Mock()
+        )
+
+    def test_related_objects_returns_empty_list_if_article_has_no_related_objects(self):
+        text = """<article article-type="DUMMY">
+            </article>"""
+        xml = etree.fromstring(text)
+        acv = self.get_article_content_validations(xml)
+        result = acv.related_objects
+        self.assertEqual([], result)
+
+    def test_related_objects_returns_ok_msg_list_if_related_object_type_is_correct(self):
+        text = """<article article-type="DUMMY">
+            <front>
+            <article-meta>
+            <related-object related-object-type="{}"/>
+            </article-meta>
+            </front>
+            </article>"""
+        for reltp in ('referee-report', 'peer-reviewed-material', ):
+            with self.subTest(reltp):
+                xml = etree.fromstring(text.format(reltp))
+                acv = self.get_article_content_validations(xml)
+                result = acv.related_objects
+                expected = [
+                    ('related-object/@related-object-type', '[OK]', reltp)]
+                self.assertEqual(expected, result)
+
+    def test_related_objects_returns_error_list_if_related_object_type_is_incorrect(self):
+        text = """<article article-type="DUMMY">
+            <front>
+            <article-meta>
+            <related-object related-object-type="{}"/>
+            </article-meta>
+            </front>
+            </article>"""
+        for reltp in ('xreferee-report', 'xpeer-reviewed-material', ):
+            with self.subTest(reltp):
+                xml = etree.fromstring(text.format(reltp))
+                acv = self.get_article_content_validations(xml)
+                result = acv.related_objects
+                expected = [
+                    ('related-object/@related-object-type',
+                        '[FATAL ERROR]',
+                        'referee-report | peer-reviewed-material')]
+
+                self.assertEqual(expected[0][0], result[0][0])
+                self.assertEqual(expected[0][1], result[0][1])
+                self.assertIn(expected[0][2], result[0][2])
+
+    def test_related_objects_returns_ok_msg_list_if_related_object_types_are_correct(self):
+        text = """<article article-type="DUMMY">
+            <front>
+            <article-meta>
+            <related-object related-object-type="referee-report"/>
+            <related-object related-object-type="referee-report"/>
+            </article-meta>
+            </front>
+            </article>"""
+        xml = etree.fromstring(text)
+        acv = self.get_article_content_validations(xml)
+        result = acv.related_objects
+        expected = [
+            ('related-object/@related-object-type', '[OK]', 'referee-report'),
+            ('related-object/@related-object-type', '[OK]', 'referee-report'),
+        ]
+        self.assertEqual(expected, result)
+
+    def test_related_objects_returns_ok_and_error_for_related_object_types_correct_and_incorrect(self):
+        text = """<article article-type="DUMMY">
+            <front>
+            <article-meta>
+            <related-object related-object-type="xxxreferee-report"/>
+            <related-object related-object-type="referee-report"/>
+            </article-meta>
+            </front>
+            </article>"""
+        xml = etree.fromstring(text)
+        acv = self.get_article_content_validations(xml)
+        result = acv.related_objects
+        expected = [
+            ('related-object/@related-object-type', '[FATAL ERROR]', 'xxxreferee-report'),
+            ('related-object/@related-object-type', '[OK]', 'referee-report'),
+        ]
+        self.assertEqual(expected[0][0], result[0][0])
+        self.assertEqual(expected[0][1], result[0][1])
+        self.assertIn(expected[0][2], result[0][2])
+        self.assertEqual(expected[1], result[1])
+
+    def test_related_objects_returns_error_because_xlink_href_is_not_doi(self):
+        text = """<article article-type="DUMMY">
+            <front>
+            <article-meta>
+            <related-object related-object-type="referee-report" ext-link-type= "doi"/>
+            </article-meta>
+            </front>
+            </article>"""
+        xml = etree.fromstring(text)
+        acv = self.get_article_content_validations(xml)
+        result = acv.related_objects
+        expected = [
+            ('related-object/@related-object-type', '[OK]', 'referee-report'),
+            ('related-object/@xlink:href', '[FATAL ERROR]', 'None'),
+        ]
+        self.assertEqual(expected[0], result[0])
+        self.assertEqual(expected[1][0], result[1][0])
+
+    def test_related_objects_returns_OK_because_xlink_href_is_doi(self):
+        text = """<article article-type="DUMMY" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+            <related-object related-object-type="referee-report" ext-link-type="doi" xlink:href="10.1590/abd1806-4841.20142998"/>
+            </article-meta>
+            </front>
+            </article>"""
+        xml = etree.fromstring(text)
+        acv = self.get_article_content_validations(xml)
+        result = acv.related_objects
+        expected = [
+            ('related-object/@related-object-type', '[OK]', 'referee-report'),
+        ]
+        self.assertEqual(expected, result)
+        


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta um novo valor para `related-article/@related-article-type` e também faz umas correções: troca `partial-article` por `partial-retraction` e completa a validação para outros valores de `related-article/@related-article-type`  e de `related-object/@related-object-type`  

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

https://github.com/scieloorg/scielo_publishing_schema/files/4833657/adendo.zip
[Arquivo Comprimido.zip](https://github.com/scieloorg/PC-Programs/files/4859137/Arquivo.Comprimido.zip)

Executar o xml_package_maker com um pacote que contenha artigos com o elemento `related-article` ou `related-object`.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots

<img width="881" alt="Captura de Tela 2020-07-01 às 13 10 34" src="https://user-images.githubusercontent.com/505143/86268954-63fde800-bb9f-11ea-80a7-98f9b31b2def.png">
<img width="880" alt="Captura de Tela 2020-07-01 às 13 20 51" src="https://user-images.githubusercontent.com/505143/86268962-66f8d880-bb9f-11ea-82d6-8075c5766d29.png">


#### Quais são tickets relevantes?
closes #3273
closes #3280
Relacionado também com #3218, #3219

### Referências
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-related-article.html
https://github.com/scieloorg/scielo_publishing_schema/issues/908

