### PR TITLE
Corrige o relatório na apresentação dos dados do documento pré-conversão

### DIFF
--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -202,7 +202,7 @@ class ArticlesConversion(object):
         db_articles = self.registered_articles or {}
         for xml_name in sorted(self.pkg_eval_result.history_items.keys()):
             pkg = self.pkg.articles.get(xml_name)
-            registered = self.registered_issue_data.registered_articles.get(xml_name)
+            registered = self.pkg_eval_result.registered_articles.get(xml_name)
             merged = db_articles.get(xml_name)
 
             diff = ''

--- a/src/scielo/bin/xml/prodtools/validations/pkg_evaluation.py
+++ b/src/scielo/bin/xml/prodtools/validations/pkg_evaluation.py
@@ -92,6 +92,7 @@ class PackageEvaluationResult(object):
         self.accepted_articles = docs_merger.accepted_articles
         self.history_items = docs_merger.history_items
         self.merged_articles = docs_merger.merged_articles
+        self.registered_articles = docs_merger.registered_articles
 
 
 class DocsMergingReports(object):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o relatório na apresentação dos dados do documento pré-conversão

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Os mesmos passos para reproduzir o problema, informado no issue.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Funcionou como esperado. Observar a data de atualização da coluna 1 e 4

<img width="1050" alt="Captura de Tela 2020-07-02 às 11 00 27" src="https://user-images.githubusercontent.com/505143/86368979-39ba3200-bc54-11ea-89ce-b25eedfd3217.png">

#### Quais são tickets relevantes?
#3287

### Referências
n/a
