### PR TITLE
Usa o valor do parâmetro WEB_PATH somente se preenchido

### DIFF
--- a/src/scielo/bin/cfg/configure_paths.py
+++ b/src/scielo/bin/cfg/configure_paths.py
@@ -49,21 +49,26 @@ def update_scielo_paths():
         ('d:\\dados\\scielo', DATADIR),
         ('c:\\programas\\scielo', APPDIR),
         ('MYSCIELOURL', MYSCIELOURL),
-        ('SCI_LISTA_SITE=c:\\var\\www\\scielo',
-            'SCI_LISTA_SITE={}'.format(WEBPATH)),
     ]
+    if WEBPATH and WEBPATH != 'c:\\var\\www\\scielo':
+        items.append(
+            ('SCI_LISTA_SITE=c:\\var\\www\\scielo',
+             'SCI_LISTA_SITE={}'.format(WEBPATH)),
+        )
 
     if os.path.exists(SCIELO_PATHS_CONFIG):
         SCIELO_PATHS_BKP = SCIELO_PATHS_CONFIG + "." + now() + ".old"
         shutil.copyfile(SCIELO_PATHS_CONFIG, SCIELO_PATHS_BKP)
 
+    c = ''
     with open(SCIELO_PATHS_TEMPLATE, 'r') as fp:
         c = fp.read()
-    with open(SCIELO_PATHS_CONFIG, 'w') as fp:
+    if c:
         for old, new in items:
             if new:
                 c = c.replace(old, new)
-        fp.write(c)
+        with open(SCIELO_PATHS_CONFIG, 'w') as fp:
+            fp.write(c)
 
 
 def create_newcode_db():


### PR DESCRIPTION
#### O que esse PR faz?
Usa o valor do parâmetro WEB_PATH somente se preenchido

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
executando o instalador sem preencher o diretório do sitio local e verificar que o arquivo que corresponde a `<scielo>`/bin/scielo_paths.ini` não substituiu `c:\\var\\www\\scielo`  por `None`.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
testado e funcionou:
<img width="394" alt="Captura de Tela 2020-07-02 às 16 40 22" src="https://user-images.githubusercontent.com/505143/86402814-d85d8780-bc82-11ea-96d8-4ef7e4326f59.png">

#### Quais são tickets relevantes?
#3283

### Referências
n/a
