### PR TITLE
Persiste o nome do pacote processado durante a utlização da área temporária

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/workarea.py
+++ b/src/scielo/bin/xml/prodtools/data/workarea.py
@@ -28,8 +28,9 @@ class File(object):
 
 class MultiDocsPackageOuputs(object):
 
-    def __init__(self, output_path):
+    def __init__(self, output_path, package_name=None):
         self.output_path = output_path
+        self.package_name = package_name or "scielo_package"
         for p in [self.reports_path, self.tmp_path,
                   self.scielo_package_path, self.pmc_package_path]:
             if not os.path.isdir(p):
@@ -46,7 +47,7 @@ class MultiDocsPackageOuputs(object):
 
     @property
     def scielo_package_path(self):
-        return os.path.join(self.output_path, 'scielo_package')
+        return os.path.join(self.output_path, self.package_name)
 
     @property
     def pmc_package_path(self):

--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -257,7 +257,7 @@ class BrokenRef(object):
 
 class PackageMaker(object):
 
-    def __init__(self, pkg_path, output_path, optimise=True):
+    def __init__(self, pkg_path, output_path, optimise=True, package_name=None):
         """
         Reempacota os arquivos de pacote SP,
         padronizando-os e/ou otimizando-os.
@@ -280,7 +280,9 @@ class PackageMaker(object):
         self.source_folder = workarea.MultiDocsPackageFolder(pkg_path)
 
         # outputs
-        self.output_folder = workarea.MultiDocsPackageOuputs(output_path)
+        self.output_folder = workarea.MultiDocsPackageOuputs(
+            output_path, package_name=package_name
+        )
 
         # destination
         self.destination_path = self.output_folder.scielo_package_path

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -142,7 +142,12 @@ class Reception(object):
     def _create_package_instance(self, source: str, output: str) -> SPPackage:
         """Cria instância da classe SPPackage para o pacote de entrada"""
 
-        package_maker = PackageMaker(source, output)
+        try:
+            package_name = os.path.splitext(os.path.basename(source))[0]
+        except (IndexError, TypeError):
+            package_name = None
+
+        package_maker = PackageMaker(source, output, package_name=package_name)
         return package_maker.pack()
 
     def convert_package(self, package_path):

--- a/src/scielo/bin/xml/tests/test_data_workarea.py
+++ b/src/scielo/bin/xml/tests/test_data_workarea.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+import tempfile
+
+from prodtools.data.workarea import MultiDocsPackageOuputs
+
+
+class TestMultiDocsPackageOuputs(unittest.TestCase):
+    def setUp(self):
+        self.temp_directory = tempfile.mkdtemp()
+        self.output_container = MultiDocsPackageOuputs(self.temp_directory)
+
+    def test_when_initialized_it_should_create_a_default_temporary_scielo_dir(self):
+        self.assertTrue(os.path.exists(self.output_container.scielo_package_path))
+
+    def test_when_initialized_it_should_create_a_default_temporary_reporth_dir(self):
+        self.assertTrue(os.path.exists(self.output_container.reports_path))
+
+    def test_when_initialized_it_should_create_a_default_temporary_tmp_dir(self):
+        self.assertTrue(os.path.exists(self.output_container.tmp_path))
+
+    def test_when_initialized_it_should_create_a_default_temporary_pmc_package_dir(
+        self,
+    ):
+        self.assertTrue(os.path.exists(self.output_container.pmc_package_path))
+
+    def test_when_used_a_package_name_it_should_create_a_temporary_scielo_dir_using_the_name(
+        self,
+    ):
+        output_container = MultiDocsPackageOuputs(
+            self.temp_directory, package_name="random-package"
+        )
+        self.assertTrue(os.path.exists(output_container.scielo_package_path))
+        self.assertTrue(output_container.scielo_package_path.endswith("random-package"))
+


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request faz com que o nome do pacote seja utilizado durante a criação de pastas temporárias que servem para o processamento do XC. Como consequência, as classes que olham para este diretório podem conhecer o nome original do pacote.

#### Onde a revisão poderia começar?

- `src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py` L: `283`

#### Como este poderia ser testado manualmente?

- Inicie um processamento do XC;
- Observe que o nome `scielo_package` não é mais utilizando quando o XC informa qual pacote está sendo processado.

Você também pode observar os testes unitários, acho que este é o jeito mais simples de entender.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?

fix #3293 

### Referências
N/A

