### PR TITLE
No XC, trata a exceção  ao incluir o pid v3 em um XML é inválido

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/kernel_document.py
+++ b/src/scielo/bin/xml/prodtools/data/kernel_document.py
@@ -76,9 +76,13 @@ def add_article_id_to_received_documents(
             LOGGER.debug("Could not find XML path for '%s' xml.", xml_name)
             return None
 
-        tree = xml_utils.get_xml_object(file_path)
-        _tree = add_article_id_to_etree(tree, pids_to_append_in_xml)
-        write_etree_to_file(_tree, file_path)
+        try:
+            tree = xml_utils.get_xml_object(file_path)
+        except xml_utils.etree.XMLSyntaxError:
+            LOGGER.info("%s is not a valid XML", file_path)
+        else:
+            _tree = add_article_id_to_etree(tree, pids_to_append_in_xml)
+            write_etree_to_file(_tree, file_path)
 
 
 def get_scielo_pid_v2(issn_id, year_and_order, order_in_issue):


### PR DESCRIPTION
#### O que esse PR faz?
No XC, trata a exceção  ao incluir o pid v3 em um XML é inválido

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executar o XC, com a condição de o PID_MANAGER estar configurado para que no fluxo de processamento haja a atribuição do pid v3 no XML. 
Crie um pacote com 1 documento e que este documento XML esteja quebrado.

```
cd /scielo/bin/xml
python xml_converter.py <path da pasta do pacote>
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Resultado:
<img width="991" alt="Captura de Tela 2020-07-07 às 09 18 30" src="https://user-images.githubusercontent.com/505143/86780215-e6b8f400-c032-11ea-9567-8c446fa9d495.png">


#### Quais são tickets relevantes?
#3291

### Referências
https://github.com/scieloorg/PC-Programs/blob/master/docs/source/xc.md
