### PR TITLE
Aumenta a relisiência durante a escrita de PIDs na base de dados SQLite

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/kernel_document.py
+++ b/src/scielo/bin/xml/prodtools/data/kernel_document.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import sqlite3
 
 from typing import Optional
 
@@ -67,9 +68,16 @@ def add_article_id_to_received_documents(
                 or pid_manager.get_pid_v3(pid_v2)
                 or scielo_id_gen.generate_scielo_pid()
             )
-            pid_manager.register(pid_v2, pid_v3)
             article.registered_scielo_id = pid_v3
             pids_to_append_in_xml.append((pid_v3, "scielo-v3"))
+
+        try:
+            pid_manager.register(pid_v2, pid_v3)
+        except sqlite3.OperationalError:
+            LOGGER.exception(
+                "Could not update sql database with pid v2 and v3."
+                " The following exception was captured."
+            )
 
         file_path = file_paths.get(xml_name)
         if file_path is None:

--- a/src/scielo/bin/xml/prodtools/db/pid_versions.py
+++ b/src/scielo/bin/xml/prodtools/db/pid_versions.py
@@ -35,11 +35,6 @@ class PIDVersionsManager:
 
 class PIDVersionsDB:
     def __init__(self, name):
-        self.conn = None
-        self.cursor = None
-        self.open(name)
-
-    def open(self, name):
         try:
             self.conn = sqlite3.connect(name)
             self.cursor = self.conn.cursor()

--- a/src/scielo/bin/xml/prodtools/db/pid_versions.py
+++ b/src/scielo/bin/xml/prodtools/db/pid_versions.py
@@ -51,7 +51,6 @@ class PIDVersionsDB:
         if self.conn is not None:
             self.conn.commit()
             self.conn.close()
-            self.cursor.close()
 
     def __enter__(self):
         return self

--- a/src/scielo/bin/xml/prodtools/db/pid_versions.py
+++ b/src/scielo/bin/xml/prodtools/db/pid_versions.py
@@ -34,9 +34,9 @@ class PIDVersionsManager:
 
 
 class PIDVersionsDB:
-    def __init__(self, name):
+    def __init__(self, name, timeout=60):
         try:
-            self.conn = sqlite3.connect(name)
+            self.conn = sqlite3.connect(name, timeout=timeout)
             self.cursor = self.conn.cursor()
         except sqlite3.OperationalError as e:
             logging.exception(e)

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -410,8 +410,10 @@ class PkgProcessor(object):
         registered_issue_data, pkg_eval_result = self.evaluate_package(pkg)
 
         conversion = ArticlesConversion(registered_issue_data, pkg, pkg_eval_result, not self.config.interative_mode, self.config.local_web_app_path, self.config.web_app_site)
-        if self.pid_manager is not None:
-            conversion.register_pids_and_update_xmls(self.pid_manager)
+
+        if self.config.pid_manager_info:
+            with PIDVersionsDB(self.config.pid_manager_info) as db:
+                conversion.register_pids_and_update_xmls(PIDVersionsManager(db))
 
         scilista_items = conversion.convert()
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -378,13 +378,6 @@ class PkgProcessor(object):
             self.config, self.is_db_generation)
         self._pid_manager = None
 
-    @property
-    def pid_manager(self):
-        if self._pid_manager is None and self.config.pid_manager_info:
-            self._pid_manager = PIDVersionsManager(
-                PIDVersionsDB(
-                    self.config.pid_manager_info))
-        return self._pid_manager
 
     @property
     def export_documents_package(self):

--- a/src/scielo/bin/xml/tests/test_kernel_document.py
+++ b/src/scielo/bin/xml/tests/test_kernel_document.py
@@ -121,7 +121,9 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             "pid-v3-registrado-anteriormente-para-documento-aop",
         )
 
-    def test_pid_manager_does_not_register_pids_if_pid_v3_already_exists_in_xml(self):
+    def test_pid_manager_should_try_to_register_pids_even_it_already_exists_in_xml(
+        self,
+    ):
 
         mock_pid_manager = Mock()
 
@@ -135,7 +137,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             update_article_with_aop_status=lambda _: _,
         )
 
-        mock_pid_manager.register.assert_not_called()
+        self.assertTrue(mock_pid_manager.register.called)
 
     def test_add_pids_to_etree_should_return_none_if_etree_is_not_valid(self):
         self.assertIsNone(kernel_document.add_article_id_to_etree(None, []))


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request faz com que o programa XC use a conexão com o banco SQLite de forma racional, mantendo a conexão aberta apenas quando necessário. Também aumenta o tempo de `5s` para `60s` durante a espera para que uma transação seja concluída.


#### Onde a revisão poderia começar?

Aconselho que a revisão seja feita por meio do histórico de commits, iniciando em 31c7355.

#### Como este poderia ser testado manualmente?

Pode-se testar este PR da seguinte forma:

- Abra duas abas do seu terminal;
- Inicie um ambiente virtual nas duas abas;
- Faça o setup do XC
    - `pip install -r src/scielo/bin/xml/requirements.txt`
    - `cd src/scielo/bin/xml/ && python setup.py test`
- Rode um IDLE do Python nas duas abas;
- Execute o trecho de código nos dois IDLE:
```python
import time
from prodtools.db.pid_versions import PIDVersionsDB, PIDVersionsManager

with PIDVersionsDB("/tmp/teste.db") as db:
    manager = PIDVersionsManager(db)
    manager.register("2", "3")
    print("Foi realizada uma tentativa de registro do pid v3")
    time.sleep(10)
    print("A conexão foi desfeita..")
```
- Observe que a conexão é encerrada a pós 10 segundos;
- Observe que a segunda aba a executar o código inicia o registro do pid logo após
ser notificada de que a transação foi concluída;


#### Algum cenário de contexto que queira dar?

Este PR não soluciona o problema de `LOCK` para escritas na tabela de pids, pelo que pude ver entre comentários e documentação do sqlite3, não há uma forma de solucionar o problema sem abrir mão da segurança da própria base com perigo de corrupção.

Por outro lado, ao fechar a conexão sempre que ela estiver em desuso nós diminuímos a chance de que o problema volte a ocorrer. Eu vejo que a única forma disto ocorrer novamente é que durante a execução do XC o programa leve mais de `60 segundos` para gravar todos os pids no banco e para que o erro aconteça uma outra execução do XC deve iniciar.

### Screenshots
N/A

#### Quais são tickets relevantes?
#3295

### Referências
N/A

