### PR TITLE
Corrige leitura de arquivos de configuração no Windows

### DIFF
--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -35,19 +35,22 @@ class Configuration(object):
             self.filename = None
         self.load()
 
-    def load(self):
-        self._data = {}
+    def read_files(self):
         content_files = ''
         for item in ['scielo_env.ini', 'scielo_collection.ini']:
-            if os.path.isfile(os.path.join(BIN_PATH, item)):
-                content_files += fs_utils.read_file(
-                    os.path.join(BIN_PATH, item)) + "\n"
+            file_path = os.path.join(BIN_PATH, item)
+            content_files += (fs_utils.read_file(file_path) or '') + "\n"
 
         if self.filename is not None:
             coding = 'utf-8'
             if self.filename.endswith('scielo_paths.ini'):
                 coding = 'iso-8859-1'
             content_files += fs_utils.read_file(self.filename, coding)
+        return content_files
+
+    def load(self):
+        content_files = self.read_files()
+        self._data = {}
         for item in content_files.splitlines():
             if '=' in item:
                 if ',' in item and '@' not in item:

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -40,8 +40,8 @@ class Configuration(object):
         content_files = ''
         for item in ['scielo_env.ini', 'scielo_collection.ini']:
             if os.path.isfile(os.path.join(BIN_PATH, item)):
-                content_files += "\n" + fs_utils.read_file(
-                    os.path.join(BIN_PATH, item))
+                content_files += fs_utils.read_file(
+                    os.path.join(BIN_PATH, item)) + "\n"
 
         if self.filename is not None:
             coding = 'utf-8'

--- a/src/scielo/bin/xml/tests/test_config.py
+++ b/src/scielo/bin/xml/tests/test_config.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+from unittest.mock import patch
+from prodtools.config.config import Configuration
+
+
+class TestConfiguration(TestCase):
+
+    def setUp(self):
+        pass
+
+    @patch("prodtools.config.config.os.path.isfile")
+    @patch("prodtools.config.config.fs_utils.read_file")
+    @patch("prodtools.config.config.os.path.join")
+    def test_read_files_returns_valid_value_for_last_variable_of_a_config_file(
+            self, mock_join, mock_read_file, mock_is_file):
+        mock_is_file.return_value = True
+        mock_join.side_effect = ['path1', 'path2']
+        mock_read_file.side_effect = [
+            'var1=valor1',
+            'var2=valor2',
+            'var3=valor3'
+        ]
+        config = Configuration('scielo_paths.ini')
+        result = config.read_files()
+        expected = "var1=valor1\nvar2=valor2\nvar3=valor3"
+        self.assertEqual(expected, result)
+
+

--- a/src/scielo/bin/xml/tests/test_config.py
+++ b/src/scielo/bin/xml/tests/test_config.py
@@ -8,11 +8,12 @@ class TestConfiguration(TestCase):
     def setUp(self):
         pass
 
+    @patch("prodtools.config.config.Configuration.load")
     @patch("prodtools.config.config.os.path.isfile")
     @patch("prodtools.config.config.fs_utils.read_file")
     @patch("prodtools.config.config.os.path.join")
     def test_read_files_returns_valid_value_for_last_variable_of_a_config_file(
-            self, mock_join, mock_read_file, mock_is_file):
+            self, mock_join, mock_read_file, mock_is_file, mock_load):
         mock_is_file.return_value = True
         mock_join.side_effect = ['path1', 'path2']
         mock_read_file.side_effect = [


### PR DESCRIPTION
#### O que esse PR faz?
Corrige leitura de arquivos de configuração no Windows que "grudava" o conteúdo de um arquivo com o contéudo do seguinte.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
No Windows, executando o XC ou instanciando a classe `prodtools.config.config.Configuration`.

#### Algum cenário de contexto que queira dar?
Diferentemente do XC do Linux, o XC do Windows pode usar mais de 1 arquivo de configuração. Originalmente o pacote de programas PC Programs já usava o arquivo `scielo_paths.ini` do qual se pode obter vários dados necessários para que o XC funcione, no entanto, com as novas versões vieram novas demandas de configuração, no entanto, opcionais, que foram resolvidas em arquivos de configuração à parte: `scielo_collection.ini` com configurações específicas da coleção e `scielo_env.ini` específicas de ambiente como proxy, acesso à internet etc.

### Screenshots
Antes

O arquivo não contém quebra de linha no final, então o último valor "gruda" com `;`

<img width="864" alt="Captura de Tela 2020-07-07 às 11 09 10" src="https://user-images.githubusercontent.com/505143/86806062-e2023900-c04e-11ea-8fbe-6805e0134c1c.png">

O arquivo com quebra de linha no final, o o último valor fica correto
<img width="869" alt="Captura de Tela 2020-07-07 às 11 10 59" src="https://user-images.githubusercontent.com/505143/86806086-e890b080-c04e-11ea-9d8b-ced7bc712f10.png">

Depois da correção

<img width="642" alt="Captura de Tela 2020-07-07 às 11 23 41" src="https://user-images.githubusercontent.com/505143/86806130-f2b2af00-c04e-11ea-9bf1-91a4cbeac3e2.png">


#### Quais são tickets relevantes?
#3299

### Referências
n/a
