### PR TITLE
Recupera algumas variáveis da instalação atual e corrige atalhos

### DIFF
--- a/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
+++ b/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
@@ -123,10 +123,6 @@ item: Set Variable
   Value=c:\scielo
 end
 item: Set Variable
-  Variable=DATADIR
-  Value=%PROGDIR%
-end
-item: Set Variable
   Variable=MYSCIELOURL
   Value=www.scielo.br
   Flags=10000000
@@ -137,16 +133,6 @@ item: Set Variable
   Flags=10000000
 end
 item: If/While Statement
-  Variable=DATADIR
-  Value=scielo
-end
-item: Set Variable
-  Variable=DATADIR
-  Value=c:\scielo
-end
-item: End Block
-end
-item: If/While Statement
   Variable=PROGDIR
   Value=scielo
 end
@@ -155,6 +141,10 @@ item: Set Variable
   Value=c:\scielo
 end
 item: End Block
+end
+item: Set Variable
+  Variable=DATADIR
+  Value=%PROGDIR%
 end
 item: Check Configuration
   Flags=10111011
@@ -252,6 +242,50 @@ item: Wizard Block
 end
 item: If/While Statement
   Variable=DISPLAY
+  Value=Select Components
+  Flags=00000100
+end
+item: Check if File/Dir Exists
+  Pathname=%PROGDIR%\bin\scielo_paths.ini
+  Flags=01000100
+end
+item: Install File
+  Source=e:\github.com\scieloorg\PC-Programs\src\scielo\bin\cfg\configure_paths.py
+  Destination=%PROGDIR%\bin\cfg\configure_paths.py
+  Flags=0000000010000010
+end
+item: Execute Program
+  Pathname=%PYTHON_PATH%\python
+  Command Line= %PROGDIR%\bin\cfg\configure_paths.py %PYTHON_PATH% %PROGDIR%
+  Flags=00000110
+end
+item: Read INI Value
+  Variable=WEBPATH
+  Pathname=%PROGDIR%\bin\scielo_paths_installed.ini
+  Section=INSTALLED
+  Item=WEBPATH
+  Default=%WEBPATH%
+end
+item: Read INI Value
+  Variable=DATADIR
+  Pathname=%PROGDIR%\bin\scielo_paths_installed.ini
+  Section=INSTALLED
+  Item=DATADIR
+  Default=%DATADIR%
+end
+item: Read INI Value
+  Variable=MYSCIELOURL
+  Pathname=%PROGDIR%\bin\scielo_paths_installed.ini
+  Section=INSTALLED
+  Item=WEBURL
+  Default=%MYSCIELOURL%
+end
+item: End Block
+end
+item: End Block
+end
+item: If/While Statement
+  Variable=DISPLAY
   Value=Select Destination Directory
   Flags=00000100
 end
@@ -273,17 +307,6 @@ item: Set Variable
   Value=Select python3 path
 end
 item: End Block
-end
-item: End Block
-end
-item: If/While Statement
-  Variable=DISPLAY
-  Value=Collection data
-  Flags=00000100
-end
-item: Set Variable
-  Variable=DATADIR
-  Value=%PROGDIR%
 end
 item: End Block
 end

--- a/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
+++ b/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
@@ -1897,7 +1897,7 @@ item: Install File
   Flags=0000000010000010
 end
 item: Execute Program
-  Pathname=pip
+  Pathname=%PYTHON_PATH%\Scripts\pip
   Command Line=install -U %PROGDIR%\bin\xml\dist\SciELO_Production_Tools-4.0.97-py3-none-any.whl
   Flags=00000110
 end
@@ -5511,7 +5511,7 @@ item: Create Shortcut
   Destination Portuguese=%DESKTOPDIR%\XML Converter.lnk
   Destination Spanish=%DESKTOPDIR%\XML Converter.lnk
   Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR%
+  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
   Command Options Spanish=%PROGDIR%
   Icon Number=0
   Icon Number Portuguese=0
@@ -5519,6 +5519,7 @@ item: Create Shortcut
   Icon Pathname=%PROGDIR%\bin\SGMLPars\Scielo.ico
   Icon Pathname Portuguese=%PROGDIR%\bin\SGMLPars\Scielo.ico
   Icon Pathname Spanish=%PROGDIR%\bin\SGMLPars\Scielo.ico
+  Key Type Portuguese=1536
   Flags=00000001
 end
 item: Create Shortcut
@@ -5529,7 +5530,7 @@ item: Create Shortcut
   Destination Portuguese=%DESKTOPDIR%\XML Package Maker.lnk
   Destination Spanish=%DESKTOPDIR%\XML Package Maker.lnk
   Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR%
+  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
   Command Options Spanish=%PROGDIR%
   Icon Number=0
   Icon Number Portuguese=0
@@ -5537,6 +5538,7 @@ item: Create Shortcut
   Icon Pathname=%PROGDIR%\bin\SGMLPars\Scielo.ico
   Icon Pathname Portuguese=%PROGDIR%\bin\SGMLPars\Scielo.ico
   Icon Pathname Spanish=%PROGDIR%\bin\SGMLPars\Scielo.ico
+  Key Type Portuguese=1536
   Flags=00000001
 end
 item: Create Shortcut
@@ -5547,7 +5549,7 @@ item: Create Shortcut
   Destination Portuguese=%DESKTOPDIR%\Markup - update journals list.lnk
   Destination Spanish=%DESKTOPDIR%\Markup - update journals list.lnk
   Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR%
+  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
   Command Options Spanish=%PROGDIR%
   Icon Number=0
   Icon Number Portuguese=0
@@ -5555,6 +5557,7 @@ item: Create Shortcut
   Icon Pathname=%PROGDIR%\bin\SGMLPars\scielo.ico
   Icon Pathname Portuguese=%PROGDIR%\bin\SGMLPars\scielo.ico
   Icon Pathname Spanish=%PROGDIR%\bin\SGMLPars\scielo.ico
+  Key Type Portuguese=1536
   Flags=00000001
 end
 item: Create Shortcut

--- a/src/scielo/bin/cfg/configure_paths.py
+++ b/src/scielo/bin/cfg/configure_paths.py
@@ -9,12 +9,13 @@ def now():
     return datetime.now().isoformat().replace(
         " ", "-").replace(".", "-").replace(":", "-")
 
-PYTHON3 = sys.argv[1]
+PYTHON3 = sys.argv[1] if len(sys.argv) > 1 else None
 APPDIR = sys.argv[2] if len(sys.argv) > 2 else None
 DATADIR = sys.argv[3] if len(sys.argv) > 3 else None
 MYSCIELOURL = sys.argv[4] if len(sys.argv) > 4 else None
 WEBPATH = sys.argv[5] if len(sys.argv) > 5 else None
 
+SCIELO_PATHS_INSTALLED = os.path.join(APPDIR, 'bin', 'scielo_paths_installed.ini')
 SCIELO_PATHS_CONFIG = os.path.join(APPDIR, 'bin', 'scielo_paths.ini')
 SCIELO_PATHS_TEMPLATE = os.path.join(APPDIR, 'bin', 'scielo_paths.example.ini')
 PARSER_CONFIG_TEMPLATE = os.path.join(
@@ -87,8 +88,33 @@ def create_newcode_db():
         os.system(cmd)
 
 
+def create_scielo_paths_installed():
+    new_names_and_values = []
+    if os.path.isfile(SCIELO_PATHS_CONFIG):
+        with open(SCIELO_PATHS_CONFIG, 'r') as fp:
+            for row in fp.readlines():
+                if "=" in row:
+                    name, value = row.split("=")
+                    v = value.lower()
+                    if name == "Serial Directory":
+                        new_names_and_values += [
+                            "DATADIR=" + value[:v.find("\\serial\\")]]
+                    elif name == "SCI_LISTA_SITE":
+                        new_names_and_values += [
+                            "WEBPATH=" + value[:v.find("\\proc\\")]]
+                    elif name == "SciELO WEB URL":
+                        new_names_and_values += ["WEBURL=" + value]
+                        break
+    if new_names_and_values:
+        with open(SCIELO_PATHS_INSTALLED, "w") as fp:
+            fp.write("[INSTALLED]\n" + "\n".join(new_names_and_values))
+
+
 if __name__ == "__main__":
-    update_parser_config()
-    update_scielo_paths()
-    create_newcode_db()
-    fix_python_path_in_mainGenerateXML()
+    if len(sys.argv) == 3:
+        create_scielo_paths_installed()
+    else:
+        update_parser_config()
+        update_scielo_paths()
+        create_newcode_db()
+        fix_python_path_in_mainGenerateXML()

--- a/src/scielo/bin/xml/download_markup_journals.bat
+++ b/src/scielo/bin/xml/download_markup_journals.bat
@@ -1,0 +1,5 @@
+set apppath=%1
+set python_call=%2
+
+cd %apppath%\bin\xml
+%python_call% download_markup_journals.py

--- a/src/scielo/bin/xml/prodtools/xml_transform.py
+++ b/src/scielo/bin/xml/prodtools/xml_transform.py
@@ -87,3 +87,7 @@ def finish(ctrl_filepath, err_filepath, result_filepath, err_msg):
         fp.write("")
     with open(ctrl_filepath, "w") as fp:
         fp.write("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scielo/bin/xml/xml_converter.bat
+++ b/src/scielo/bin/xml/xml_converter.bat
@@ -1,0 +1,5 @@
+set apppath=%1
+set python_call=%2
+
+cd %apppath%\bin\xml
+%python_call% xm_converter.py

--- a/src/scielo/bin/xml/xml_package_maker.bat
+++ b/src/scielo/bin/xml/xml_package_maker.bat
@@ -1,0 +1,5 @@
+set apppath=%1
+set python_call=%2
+
+cd %apppath%\bin\xml
+%python_call% xm_package_maker.py


### PR DESCRIPTION
#### O que esse PR faz?
Recupera algumas variáveis da instalação atual para uso na instalação nova e corrige atalhos

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o instalador

#### Algum cenário de contexto que queira dar?
O arquivo `scielo_paths.ini` era inicialmente para configurar Title Manager, Converter e demais programas do PC Programs. Foi aproveitado para fornecer dados para XML Converter. Para o instalador, teve que ser feita uma adequação para que pudesse ser lido como um arquivo `.ini` padrão. Algumas variáveis tiveram que mudar de nome e também seu conteúdo foi adequado para obter o valor desejado.

### Screenshots
Na tela para preencher as variáveis, estas podem ser as recuperadas da instalação atual para uso na nova.

https://raw.githubusercontent.com/scieloorg/PC-Programs/master/docs/source/img/install_collection_data.png

#### Quais são tickets relevantes?
#3302 

### Referências
https://github.com/scieloorg/PC-Programs/blob/master/docs/source/xml_gestao_install.md
