### PR TITLE
Corrige leitura de arquivos de configuração

### DIFF
--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -38,20 +38,21 @@ def _clean_item(pair):
 class Configuration(object):
 
     def __init__(self, filename=None):
-        filename = filename or get_configuration_filename()
-
         self._data = {}
         content_files = ''
+
+        filename = filename or get_configuration_filename()
+        if filename:
+            coding = 'utf-8'
+            if filename.endswith('scielo_paths.ini'):
+                coding = 'iso-8859-1'
+            content_files += fs_utils.read_file(filename, coding)
+
         for item in ['scielo_env.ini', 'scielo_collection.ini']:
             if os.path.isfile(os.path.join(BIN_PATH, item)):
                 content_files += "\n" + fs_utils.read_file(
                     os.path.join(BIN_PATH, item))
 
-        if filename is not None:
-            coding = 'utf-8'
-            if filename.endswith('scielo_paths.ini'):
-                coding = 'iso-8859-1'
-            content_files += fs_utils.read_file(filename, coding)
         for item in content_files.splitlines():
             if '=' in item:
                 if ',' in item and '@' not in item:

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -13,14 +13,12 @@ from prodtools import EMAIL_TEMPLATE_MESSAGES_PATH
 
 def get_configuration_filename(collection_acron=None):
     filename = None
-    if collection_acron is None:
-        f = os.path.join(BIN_PATH, 'scielo_paths.ini')
-        if os.path.isfile(f):
-            filename = f
+    if collection_acron:
+        f = os.path.join(XC_SERVER_CONFIG_PATH, collection_acron + '.xc.ini')
     else:
-        filename = os.path.join(
-            XC_SERVER_CONFIG_PATH, collection_acron + '.xc.ini')
-
+        f = os.path.join(BIN_PATH, 'scielo_paths.ini')
+    if os.path.isfile(f):
+        filename = f
     return filename
 
 

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -28,9 +28,7 @@ class Configuration(object):
 
     def __init__(self, filename=None):
         self.filename = filename or get_configuration_filename()
-        self.load()
 
-    def load(self):
         self._data = {}
         content_files = ''
         for item in ['scielo_env.ini', 'scielo_collection.ini']:

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import os
 import shutil
+import configparser
 
 from prodtools.utils import fs_utils
 from prodtools.utils import encoding
@@ -33,6 +34,14 @@ def _clean_item(pair):
     if v == "":
         v = None
     return k, v
+
+
+def get_data(content: str) -> dict:
+    cp = configparser.ConfigParser()
+    # evita de converter nomes das variaveis para lowercase
+    cp.optionxform = lambda option: option
+    cp.read_string("[DUMMYSECTION]\n" + content)
+    return dict([_clean_item(i) for i in cp.items("DUMMYSECTION")])
 
 
 class Configuration(object):

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -22,6 +22,19 @@ def get_configuration_filename(collection_acron=None):
     return filename
 
 
+def _clean_item(pair):
+    """
+    Trata valores provenientes do arquivos scielo_paths.ini usado para atender
+    Title Manager, Converter entre outras aplicações
+    """
+    k, v = pair
+    if "," in v and "@" not in v:
+        v = v[0:v.rfind(",")]
+    if v == "":
+        v = None
+    return k, v
+
+
 class Configuration(object):
 
     def __init__(self, filename=None):

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -37,6 +37,8 @@ def _clean_item(pair):
 
 
 def get_data(content: str) -> dict:
+    if not content:
+        return {}
     cp = configparser.ConfigParser()
     # evita de converter nomes das variaveis para lowercase
     cp.optionxform = lambda option: option
@@ -48,29 +50,18 @@ class Configuration(object):
 
     def __init__(self, filename=None):
         self._data = {}
-        content_files = ''
 
         filename = filename or get_configuration_filename()
         if filename:
             coding = 'utf-8'
             if filename.endswith('scielo_paths.ini'):
                 coding = 'iso-8859-1'
-            content_files += fs_utils.read_file(filename, coding)
+            self._data.update(get_data(fs_utils.read_file(filename, coding)))
 
         for item in ['scielo_env.ini', 'scielo_collection.ini']:
-            if os.path.isfile(os.path.join(BIN_PATH, item)):
-                content_files += "\n" + fs_utils.read_file(
-                    os.path.join(BIN_PATH, item))
+            file_path = os.path.join(BIN_PATH, item)
+            self._data.update(get_data(fs_utils.read_file(file_path)))
 
-        for item in content_files.splitlines():
-            if '=' in item:
-                if ',' in item and '@' not in item:
-                    item = item[0:item.rfind(',')]
-                key, value = item.split('=')
-                if value == '':
-                    self._data[key] = None
-                else:
-                    self._data[key] = value
         self.interative_mode = self._data.get('Serial Directory') is not None
         self.is_windows = self.interative_mode
 

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -27,12 +27,7 @@ def get_configuration_filename(collection_acron=None):
 class Configuration(object):
 
     def __init__(self, filename=None):
-        self.filename = filename
-        if filename is None:
-            self.filename = get_configuration_filename()
-        if self.filename is not None and not os.path.isfile(self.filename):
-            encoding.display_message('Not found {}'.format(self.filename))
-            self.filename = None
+        self.filename = filename or get_configuration_filename()
         self.load()
 
     def load(self):

--- a/src/scielo/bin/xml/prodtools/config/config.py
+++ b/src/scielo/bin/xml/prodtools/config/config.py
@@ -27,7 +27,7 @@ def get_configuration_filename(collection_acron=None):
 class Configuration(object):
 
     def __init__(self, filename=None):
-        self.filename = filename or get_configuration_filename()
+        filename = filename or get_configuration_filename()
 
         self._data = {}
         content_files = ''
@@ -36,11 +36,11 @@ class Configuration(object):
                 content_files += "\n" + fs_utils.read_file(
                     os.path.join(BIN_PATH, item))
 
-        if self.filename is not None:
+        if filename is not None:
             coding = 'utf-8'
-            if self.filename.endswith('scielo_paths.ini'):
+            if filename.endswith('scielo_paths.ini'):
                 coding = 'iso-8859-1'
-            content_files += fs_utils.read_file(self.filename, coding)
+            content_files += fs_utils.read_file(filename, coding)
         for item in content_files.splitlines():
             if '=' in item:
                 if ',' in item and '@' not in item:

--- a/src/scielo/bin/xml/tests/test_config.py
+++ b/src/scielo/bin/xml/tests/test_config.py
@@ -1,11 +1,30 @@
 from unittest import TestCase
-from prodtools.config.config import get_data
+from unittest.mock import patch
+from prodtools.config.config import (
+    get_data,
+    Configuration
+)
 
 
 scielo_collection = """
 CODED_FORMULA_REQUIRED=on
 CODED_TABLE_REQUIRED=on
 BLOCK_DISAGREEMENT_WITH_COLLECTION_CRITERIA=off
+"""
+
+scielo_env = """
+PROXY_ADDRESS=123.456.789:1234
+ENABLED_WEB_ACCESS=off
+XML_STRUCTURE_VALIDATOR_PREFERENCE_ORDER=packtools|java
+"""
+
+scielo_paths = """
+;
+package_version=4.0
+; Arquivo de configuração dos caminhos
+; SGML Parser
+SGML Parser Program Directory=c:\\programas\\scielo\\bin\\sgmlpars\\,required
+SGML Parser Program=c:\\programas\\scielo\\bin\\sgmlpars\\parser.exe,required
 """
 
 
@@ -17,5 +36,48 @@ class TestConfig(TestCase):
             "CODED_FORMULA_REQUIRED": "on",
             "CODED_TABLE_REQUIRED": "on",
             "BLOCK_DISAGREEMENT_WITH_COLLECTION_CRITERIA": "off",
+        }
+        self.assertEqual(expected, result)
+
+    def test_get_data_returns_empty_dict(self):
+        result = get_data(None)
+        expected = {}
+        self.assertEqual(expected, result)
+
+    def test_get_data_handles_odd_ini_content_and_returns_dict(self):
+        result = get_data(scielo_paths)
+        expected = {
+            "package_version": "4.0",
+            "SGML Parser Program Directory": "c:\\programas\\scielo\\bin\\sgmlpars\\",
+            "SGML Parser Program": "c:\\programas\\scielo\\bin\\sgmlpars\\parser.exe",
+        }
+        self.assertEqual(expected, result)
+
+
+class TestConfiguration(TestCase):
+
+    @patch("prodtools.config.config.get_configuration_filename")
+    @patch("prodtools.config.config.fs_utils.read_file")
+    def test_init_updates_data_with_config_files_content(self, mock_read_file,
+            mock_get_configuration_filename):
+        # para garantir que executará read_file 3 vezes
+        mock_get_configuration_filename.return_value = "scielo_paths.ini"
+        mock_read_file.side_effect = [
+            scielo_paths,
+            scielo_collection,
+            scielo_env,
+        ]
+        c = Configuration()
+        result = c._data
+        expected = {
+            "package_version": "4.0",
+            "SGML Parser Program Directory": "c:\\programas\\scielo\\bin\\sgmlpars\\",
+            "SGML Parser Program": "c:\\programas\\scielo\\bin\\sgmlpars\\parser.exe",
+            "CODED_FORMULA_REQUIRED": "on",
+            "CODED_TABLE_REQUIRED": "on",
+            "BLOCK_DISAGREEMENT_WITH_COLLECTION_CRITERIA": "off",
+            "PROXY_ADDRESS": "123.456.789:1234",
+            "ENABLED_WEB_ACCESS": "off",
+            "XML_STRUCTURE_VALIDATOR_PREFERENCE_ORDER": "packtools|java",
         }
         self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_config.py
+++ b/src/scielo/bin/xml/tests/test_config.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from prodtools.config.config import get_data
+
+
+scielo_collection = """
+CODED_FORMULA_REQUIRED=on
+CODED_TABLE_REQUIRED=on
+BLOCK_DISAGREEMENT_WITH_COLLECTION_CRITERIA=off
+"""
+
+
+class TestConfig(TestCase):
+
+    def test_get_data_returns_dict(self):
+        result = get_data(scielo_collection)
+        expected = {
+            "CODED_FORMULA_REQUIRED": "on",
+            "CODED_TABLE_REQUIRED": "on",
+            "BLOCK_DISAGREEMENT_WITH_COLLECTION_CRITERIA": "off",
+        }
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige leitura de arquivos de configuração no Windows que "grudava" o conteúdo de um arquivo com o contéudo do seguinte.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando a classe `prodtools.config.config.Configuration` com os arquivos em anexo que devem ser colocados em `/scielo/bin/`.
[Arquivo Comprimido.zip](https://github.com/scieloorg/PC-Programs/files/4891880/Arquivo.Comprimido.zip)

Execute dentro de `/scielo/bin/xml`

```python
from prodtools.config.config import Configuration
c = Configuration()
c._data
```
Verifique não há `;` no final de nenhum valor

#### Algum cenário de contexto que queira dar?
O problema ocorre quando após o último valor do arquivo de configuração não há uma quebra de linha.

Diferentemente do XC do Linux, o XC do Windows pode usar mais de 1 arquivo de configuração. Originalmente o pacote de programas PC Programs já usava o arquivo `scielo_paths.ini` do qual se pode obter vários dados necessários para que o XC funcione, no entanto, com as novas versões vieram novas demandas de configuração, no entanto, opcionais, que foram resolvidas em arquivos de configuração à parte: `scielo_collection.ini` com configurações específicas da coleção e `scielo_env.ini` específicas de ambiente como proxy, acesso à internet etc.

### Screenshots
n/a

#### Quais são tickets relevantes?
#3299

### Referências
n/a
