### PR TITLE
Corrige a validação de intervalos de citações

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -607,11 +607,18 @@ class ArticleXML(object):
 
     @property
     def any_xref_parent_nodes(self):
+        """
+        Retorna os filhos de `body` que contém xref e os respectivos `xref`s
+        dentro de um dicionário cuja chave é o tipo do xref (`xref/@ref-type`)
+        e os valores são uma tupla de (`body child node`, lista de `xref nodes`)
+        """
         _any_xref_parent_nodes = {}
         if self.tree is not None:
-            for xref_parent_node in self.tree.findall('.//*[xref]'):
+            total = len(self.tree.findall('.//xref'))
+            for xref_parent_node in self.tree.xpath(".//body/*"):
                 xref_nodes = {}
                 for xref_node in xref_parent_node.findall('.//xref'):
+                    total -= 1
                     xref_type = xref_node.attrib.get('ref-type')
                     if xref_type not in xref_nodes.keys():
                         xref_nodes[xref_type] = []
@@ -625,6 +632,8 @@ class ArticleXML(object):
                         # considerar apenas quando há mais de 1 xref[@ref-type='<any>']
                         # pois range somente éh possível a partir de 2
                         _any_xref_parent_nodes[xref_type].append((xref_parent_node, xref_type_nodes))
+                if total == 0:
+                    break
         return _any_xref_parent_nodes
 
     @property

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -567,42 +567,43 @@ class ArticleXML(object):
     def any_xref_ranges(self):
         _any_xref_ranges = {}
         for xref_type, xref_type_nodes in self.any_xref_parent_nodes.items():
-            if xref_type is not None:
-                if xref_type not in _any_xref_ranges.keys():
-                    _any_xref_ranges[xref_type] = []
-                for xref_parent_node, xref_node_items in xref_type_nodes:
-                    # nodes de um tipo de xref
-                    xref_parent_xml = tostring(xref_parent_node)
-                    parts = xref_parent_xml.replace('<xref', '~BREAK~<xref').split('~BREAK~')
-                    parts = [item for item in parts if ' ref-type="' + xref_type + '"' in item]
-                    k = 0
-                    for item in parts:
-                        text = ''
-                        delimiter = ''
-                        if '</xref>' in item:
-                            delimiter = '</xref>'
-                        elif '/>' in item:
-                            delimiter = '/>'
-                        if len(delimiter) > 0:
-                            if delimiter in item:
-                                text = item[item.find(delimiter)+len(delimiter):]
-                        if text.replace('</sup>', '').replace('<sup>', '').startswith('-'):
-                            start = None
-                            end = None
-                            n = xref_node_items[k].attrib.get('rid')
+            if xref_type is None:
+                continue
+            if xref_type not in _any_xref_ranges.keys():
+                _any_xref_ranges[xref_type] = []
+            for xref_parent_node, xref_node_items in xref_type_nodes:
+                # nodes de um tipo de xref
+                xref_parent_xml = tostring(xref_parent_node)
+                parts = xref_parent_xml.replace('<xref', '~BREAK~<xref').split('~BREAK~')
+                parts = [item for item in parts if ' ref-type="' + xref_type + '"' in item]
+                k = 0
+                for item in parts:
+                    text = ''
+                    delimiter = ''
+                    if '</xref>' in item:
+                        delimiter = '</xref>'
+                    elif '/>' in item:
+                        delimiter = '/>'
+                    if len(delimiter) > 0:
+                        if delimiter in item:
+                            text = item[item.find(delimiter)+len(delimiter):]
+                    if text.replace('</sup>', '').replace('<sup>', '').startswith('-'):
+                        start = None
+                        end = None
+                        n = xref_node_items[k].attrib.get('rid')
+                        if n is not None:
+                            n = n[1:]
+                            if n.isdigit():
+                                start = int(n)
+                        if k + 1 < len(xref_node_items):
+                            n = xref_node_items[k+1].attrib.get('rid')
                             if n is not None:
                                 n = n[1:]
                                 if n.isdigit():
-                                    start = int(n)
-                            if k + 1 < len(xref_node_items):
-                                n = xref_node_items[k+1].attrib.get('rid')
-                                if n is not None:
-                                    n = n[1:]
-                                    if n.isdigit():
-                                        end = int(n)
-                                if all([start, end]):
-                                    _any_xref_ranges[xref_type].append([start, end, xref_node_items[k], xref_node_items[k+1]])
-                        k += 1
+                                    end = int(n)
+                            if all([start, end]):
+                                _any_xref_ranges[xref_type].append([start, end, xref_node_items[k], xref_node_items[k+1]])
+                    k += 1
         return _any_xref_ranges
 
     @property

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -668,16 +668,16 @@ class ArticleXML(object):
 
     @property
     def is_bibr_xref_number(self):
-        _is_bibr_xref_number = False
-        if self.bibr_xref_nodes is not None:
-            for bibr_xref in self.bibr_xref_nodes:
-                if bibr_xref.text is not None:
-                    if bibr_xref.text.replace('(', '')[0].isdigit():
-                        _is_bibr_xref_number = True
-                    else:
-                        _is_bibr_xref_number = False
-                    break
-        return _is_bibr_xref_number
+        """
+        Se encontrar pelo menos um caracter alfabético,
+        considerar que NÃO é o padrão numérico.
+        """
+        for node in self.tree.findall('.//xref[@ref-type="bibr"]'):
+            for words in node.itertext():
+                for c in words:
+                    if c.isalpha():
+                        return False
+        return True
 
     @property
     def bibr_xref_parent_nodes(self):

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -599,3 +599,11 @@ def strip_all_tags_except(root, keep_tags):
             continue
         node.tag = "REMOVE"
     etree.strip_tags(root, "REMOVE")
+
+
+def node_text(node):
+    """
+    Retorna todos os textos encontrados dentro de um elemento e de seus
+    sub-elementos de forma concatenada
+    """
+    return "".join(node.itertext())

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -591,3 +591,11 @@ def nodes_tostring(root, node_xpaths):
     que combinam com uma lista de xpaths
     """
     return [tostring(node) for node in find_nodes(root, node_xpaths)]
+
+
+def strip_all_tags_except(root, keep_tags):
+    for node in root.findall(".//*"):
+        if node.tag in keep_tags:
+            continue
+        node.tag = "REMOVE"
+    etree.strip_tags(root, "REMOVE")

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1387,13 +1387,13 @@ class ArticleContentValidation(object):
                 for start, end, start_node, end_node in self.article.any_xref_ranges.get(xref_type):
                     if start > end:
                         message.append(
-                                (
+                            (
                                 _('xref range'),
                                 validation_status.STATUS_ERROR,
-                                _('Invalid range ')+
+                                _('Invalid range ') +
                                 '{}-{} ({}-{})'.format(
-                                    start_node.text,
-                                    end_node.text,
+                                    xml_utils.node_text(start_node),
+                                    xml_utils.node_text(end_node),
                                     start_node.attrib.get('rid'),
                                     end_node.attrib.get('rid'))
                                 )

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1404,7 +1404,9 @@ class ArticleContentValidation(object):
                                 xml_utils.node_text(start_node),
                                 xml_utils.node_text(end_node),
                                 start_node.attrib.get('rid'),
-                                end_node.attrib.get('rid'))
+                                end_node.attrib.get('rid')),
+                            xml_utils.tostring(start_node) + "-" +
+                            xml_utils.tostring(end_node)
                             )
                         )
         return message

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1350,6 +1350,11 @@ class ArticleContentValidation(object):
 
     @property
     def missing_xref_list(self):
+        """
+        Verifica para todos os elementos que possuem `@id` se está ausente a
+        sua referência `xref[@rid]`
+        Também indica erro para intervalos inválidos
+        """
         tag_and_xref_types = {
             'fig-group': 'fig',
             'table-wrap-group': 'table',
@@ -1373,8 +1378,11 @@ class ArticleContentValidation(object):
                     for item in xref_nodes:
                         msg = data_validations.is_expected_value('xref[@rid="' + str(item['rid']) + '"]/@ref-type', str(item['ref-type']), [str(xref_type)],validation_status.STATUS_FATAL_ERROR)
                         message.append(msg)
+
+        any_xref_ranges = self.article.any_xref_ranges
+
         for xref_type, missing_xref_type_items in missing.items():
-            xref_ranges = self.article.any_xref_ranges.get(xref_type)
+            xref_ranges = any_xref_ranges.get(xref_type)
             if xref_ranges:
                 missing_xref_type_items = confirm_missing_xref_items(missing_xref_type_items, xref_ranges)
             else:
@@ -1383,6 +1391,8 @@ class ArticleContentValidation(object):
             for xref in missing_xref_type_items:
                 message.append(('xref[@ref-type=' + xref_type + ']', validation_status.STATUS_ERROR, 
                     _('Not found: {label}. ').format(label='xref[@ref-type="{xreftype}" and rid="{rid}"]'.format(xreftype=xref_type, rid=xref))))
+
+        for xref_type, xref_ranges in any_xref_ranges.items():
             for start, end, start_node, end_node in xref_ranges:
                 if start > end:
                     message.append(

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1374,30 +1374,29 @@ class ArticleContentValidation(object):
                         msg = data_validations.is_expected_value('xref[@rid="' + str(item['rid']) + '"]/@ref-type', str(item['ref-type']), [str(xref_type)],validation_status.STATUS_FATAL_ERROR)
                         message.append(msg)
         for xref_type, missing_xref_type_items in missing.items():
-            if self.article.any_xref_ranges.get(xref_type) is None:
-                encoding.debugging('missing_xref_list()', xref_type + ' has no xref ranges')
+            xref_ranges = self.article.any_xref_ranges.get(xref_type)
+            if xref_ranges:
+                missing_xref_type_items = confirm_missing_xref_items(missing_xref_type_items, xref_ranges)
             else:
-                missing_xref_type_items = confirm_missing_xref_items(missing_xref_type_items, self.article.any_xref_ranges.get(xref_type))
+                encoding.debugging('missing_xref_list()', xref_type + ' has no xref ranges')
 
-            if len(missing_xref_type_items) > 0:
-                for xref in missing_xref_type_items:
-                    message.append(('xref[@ref-type=' + xref_type + ']', validation_status.STATUS_ERROR, 
-                        _('Not found: {label}. ').format(label='xref[@ref-type="{xreftype}" and rid="{rid}"]'.format(xreftype=xref_type, rid=xref))))
-            if self.article.any_xref_ranges.get(xref_type) is not None:
-                for start, end, start_node, end_node in self.article.any_xref_ranges.get(xref_type):
-                    if start > end:
-                        message.append(
-                            (
-                                _('xref range'),
-                                validation_status.STATUS_ERROR,
-                                _('Invalid range ') +
-                                '{}-{} ({}-{})'.format(
-                                    xml_utils.node_text(start_node),
-                                    xml_utils.node_text(end_node),
-                                    start_node.attrib.get('rid'),
-                                    end_node.attrib.get('rid'))
-                                )
+            for xref in missing_xref_type_items:
+                message.append(('xref[@ref-type=' + xref_type + ']', validation_status.STATUS_ERROR, 
+                    _('Not found: {label}. ').format(label='xref[@ref-type="{xreftype}" and rid="{rid}"]'.format(xreftype=xref_type, rid=xref))))
+            for start, end, start_node, end_node in xref_ranges:
+                if start > end:
+                    message.append(
+                        (
+                            _('xref range'),
+                            validation_status.STATUS_ERROR,
+                            _('Invalid range ') +
+                            '{}-{} ({}-{})'.format(
+                                xml_utils.node_text(start_node),
+                                xml_utils.node_text(end_node),
+                                start_node.attrib.get('rid'),
+                                end_node.attrib.get('rid'))
                             )
+                        )
         return message
 
     @property

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -110,8 +110,78 @@ class TestArticle(TestCase):
             "bibr":
                 [[1, 2, xml.find(".//xref[1]"), xml.find(".//xref[2]")],
                  [5, 8, xml.find(".//xref[3]"), xml.find(".//xref[4]")],
-                ],
+                 ],
             "fig":
                 [[1, 2, xml.find(".//xref[5]"), xml.find(".//xref[6]")]]
         }
         self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_one_parent_and_one_xref(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {"bibr": []}
+
+        self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_one_parent_and_two_xref(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '-<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {
+            "bibr":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[1]"),
+                     xml.find(".//xref[2]")]),
+                 ],
+        }
+        self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_two_parents_and_six_children(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">1</xref>'
+            '-<xref ref-type="bibr" rid="B02">2</xref>'
+            '<xref ref-type="bibr" rid="B05">5</xref>'
+            '-<xref ref-type="bibr" rid="B08">8</xref>'
+            '<xref ref-type="fig" rid="f01">1</xref>'
+            '-<xref ref-type="fig" rid="f02">2</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {
+            "bibr":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[1]"),
+                     xml.find(".//xref[2]"),
+                     xml.find(".//xref[3]"),
+                     xml.find(".//xref[4]"),
+                     ]),
+                 ],
+            "fig":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[5]"),
+                     xml.find(".//xref[6]")]),
+                 ],
+        }
+        self.assertEqual(expected, result)
+

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from prodtools.data.article import Article
+from prodtools.utils import xml_utils
+
+
+class TestArticle(TestCase):
+
+    def test_is_bibr_xref_number_returns_true(self):
+        text = (
+            '<article>'
+            '<body><p><xref ref-type="bibr" rid="B01">(1)</xref></p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.is_bibr_xref_number
+        expected = True
+        self.assertEqual(expected, result)
+
+    def test_is_bibr_xref_number_returns_false(self):
+        text = (
+            '<article>'
+            '<body><p><xref ref-type="bibr" rid="B01">(a1)</xref></p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.is_bibr_xref_number
+        expected = False
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -70,7 +70,9 @@ class TestArticle(TestCase):
         xml, error = xml_utils.load_xml(text)
         a = Article(xml, "nome")
         result = a.any_xref_ranges
-        expected = {"bibr": []}
+        expected = {
+            "bibr":
+            [[1, 1, xml.find(".//xref[1]"), xml.find(".//xref[2]")]]}
         self.assertEqual(expected, result)
 
     def test_any_xref_ranges_returns_dict_bibr_as_key_and_one_item_list(self):

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -185,3 +185,97 @@ class TestArticle(TestCase):
         }
         self.assertEqual(expected, result)
 
+    def test_any_xref_ranges_returns_dict_with_two_items(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>1</sup></xref>'
+            '-<xref ref-type="bibr" rid="B02"><sup>2</sup></xref>'
+            '<xref ref-type="bibr" rid="B05"><sup>5</sup></xref>'
+            '-<xref ref-type="bibr" rid="B08"><sup>8</sup></xref>'
+            '<xref ref-type="fig" rid="f01"><sup>1</sup></xref>'
+            '-<xref ref-type="fig" rid="f02"><sup>2</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_ranges
+        expected = {
+            "bibr":
+                [[1, 2, xml.find(".//xref[1]"), xml.find(".//xref[2]")],
+                 [5, 8, xml.find(".//xref[3]"), xml.find(".//xref[4]")],
+                 ],
+            "fig":
+                [[1, 2, xml.find(".//xref[5]"), xml.find(".//xref[6]")]]
+        }
+        self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_one_parent_and_one_xref(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {"bibr": []}
+
+        self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_one_parent_and_two_xref(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '-<xref ref-type="bibr" rid="B01">(a1)</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {
+            "bibr":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[1]"),
+                     xml.find(".//xref[2]")]),
+                 ],
+        }
+        self.assertEqual(expected, result)
+
+    def test_any_xref_parent_nodes_returns_two_parents_and_six_children(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01">1</xref>'
+            '-<xref ref-type="bibr" rid="B02">2</xref>'
+            '<xref ref-type="bibr" rid="B05">5</xref>'
+            '-<xref ref-type="bibr" rid="B08">8</xref>'
+            '<xref ref-type="fig" rid="f01">1</xref>'
+            '-<xref ref-type="fig" rid="f02">2</xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_parent_nodes
+        expected = {
+            "bibr":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[1]"),
+                     xml.find(".//xref[2]"),
+                     xml.find(".//xref[3]"),
+                     xml.find(".//xref[4]"),
+                     ]),
+                 ],
+            "fig":
+                [(xml.find(".//p[1]"),
+                    [xml.find(".//xref[5]"),
+                     xml.find(".//xref[6]")]),
+                 ],
+        }
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -12,7 +12,7 @@ class TestArticle(TestCase):
             '<body><p><xref ref-type="bibr" rid="B01">(1)</xref></p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.is_bibr_xref_number
         expected = True
@@ -24,7 +24,7 @@ class TestArticle(TestCase):
             '<body><p><xref ref-type="bibr" rid="B01">(a1)</xref></p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.is_bibr_xref_number
         expected = False
@@ -38,7 +38,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.is_bibr_xref_number
         expected = False
@@ -52,7 +52,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_ranges
         expected = {"bibr": []}
@@ -67,7 +67,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_ranges
         expected = {
@@ -84,7 +84,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_ranges
         expected = {
@@ -105,7 +105,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_ranges
         expected = {
@@ -126,7 +126,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_parent_nodes
         expected = {"bibr": []}
@@ -142,7 +142,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_parent_nodes
         expected = {
@@ -167,7 +167,7 @@ class TestArticle(TestCase):
             '</p></body>'
             '</article>'
         )
-        xml, error = xml_utils.load_xml(text)
+        xml = xml_utils.etree.fromstring(text)
         a = Article(xml, "nome")
         result = a.any_xref_parent_nodes
         expected = {
@@ -187,97 +187,51 @@ class TestArticle(TestCase):
         }
         self.assertEqual(expected, result)
 
-    def test_any_xref_ranges_returns_dict_with_two_items(self):
-        text = (
-            '<article>'
-            '<body><p>'
-            '<xref ref-type="bibr" rid="B01"><sup>1</sup></xref>'
-            '-<xref ref-type="bibr" rid="B02"><sup>2</sup></xref>'
-            '<xref ref-type="bibr" rid="B05"><sup>5</sup></xref>'
-            '-<xref ref-type="bibr" rid="B08"><sup>8</sup></xref>'
-            '<xref ref-type="fig" rid="f01"><sup>1</sup></xref>'
-            '-<xref ref-type="fig" rid="f02"><sup>2</sup></xref>'
-            '</p></body>'
-            '</article>'
-        )
-        xml, error = xml_utils.load_xml(text)
-        a = Article(xml, "nome")
-        result = a.any_xref_ranges
-        expected = {
-            "bibr":
-                [[1, 2, xml.find(".//xref[1]"), xml.find(".//xref[2]")],
-                 [5, 8, xml.find(".//xref[3]"), xml.find(".//xref[4]")],
-                 ],
-            "fig":
-                [[1, 2, xml.find(".//xref[5]"), xml.find(".//xref[6]")]]
-        }
+
+class TestArticleXref(TestCase):
+
+    def setUp(self):
+        text = """<article><body>
+        <p>Los estudios históricos sobre ... 
+        me refiero a las listas de A. 
+        <xref ref-type="bibr" rid="B61">Thurm (1883</xref>) o de Th. 
+        <xref ref-type="bibr" rid="B9">Botten-Wobst (1876</xref>); 
+        además, este último se ocupa solo de las misiones en Roma. 
+        Hay un trabajo más reciente, el de P. 
+        <xref ref-type="bibr" rid="B43">Knibbe (1958</xref>), 
+        ... por E. <xref ref-type="bibr" rid="B44">Krug (1916</xref>);
+        y el segundo es el realizado por B.
+        <xref ref-type="bibr" rid="B54">Schleussner (1978</xref>), 
+        a los escritos de C. 
+        <xref ref-type="bibr" rid="B48">Phillipson (1911</xref>), 
+        de P. <xref ref-type="bibr" rid="B68">Willems (1878</xref>-1885), 
+        de P. <xref ref-type="bibr" rid="B39">Frezza (1938</xref>), 
+        pero sobre todo, a los de P. Catalano (1974) y F. de Martino (1972-1975).</p>
+
+        <p>Entre los análisis más recientes están el de B. E. Thomason (1991), 
+        ...; F. <xref ref-type="bibr" rid="B15">Canali de Rossi (1997</xref>) 
+        ... de ocho volúmenes (2005, 2007, 2013, 2014, 2016, 2017 (dos) 
+        y 2018). Destacan también las obras de C. 
+        <xref ref-type="bibr" rid="B2">Aulliard (2006</xref>) y 
+        de E. <xref ref-type="bibr" rid="B58">Torregaray (2005</xref>-2014): 
+        la primera es una valiosa síntesis de una ... 
+        dirigidas por Ed. 
+        <xref ref-type="bibr" rid="B40">Frézouls y A. Jacquemin (1995</xref>) 
+        y de Claude <xref ref-type="bibr" rid="B36">Eilers (2009</xref>).</p>
+        </body></article>"""
+        xml = xml_utils.etree.fromstring(text)
+        self.a = Article(xml, "nome")
+
+    def test_any_xref_parent_nodes_returns_two_tuples_for_bibr(self):
+        result = self.a.any_xref_parent_nodes
+        nodes_p = self.a.tree.findall(".//p")
+        nodes_xref = self.a.tree.findall(".//xref")
+        tuple1 = nodes_p[0], nodes_xref[:8]
+        tuple2 = nodes_p[1], nodes_xref[8:]
+        expected = {"bibr": [tuple1, tuple2]}
         self.assertEqual(expected, result)
 
-    def test_any_xref_parent_nodes_returns_one_parent_and_one_xref(self):
-        text = (
-            '<article>'
-            '<body><p>'
-            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
-            '</p></body>'
-            '</article>'
-        )
-        xml, error = xml_utils.load_xml(text)
-        a = Article(xml, "nome")
-        result = a.any_xref_parent_nodes
+    def test_any_xref_ranges_returns_empty_dict_because_there_is_no_range(self):
+        result = self.a.any_xref_ranges
         expected = {"bibr": []}
-
-        self.assertEqual(expected, result)
-
-    def test_any_xref_parent_nodes_returns_one_parent_and_two_xref(self):
-        text = (
-            '<article>'
-            '<body><p>'
-            '<xref ref-type="bibr" rid="B01">(a1)</xref>'
-            '-<xref ref-type="bibr" rid="B01">(a1)</xref>'
-            '</p></body>'
-            '</article>'
-        )
-        xml, error = xml_utils.load_xml(text)
-        a = Article(xml, "nome")
-        result = a.any_xref_parent_nodes
-        expected = {
-            "bibr":
-                [(xml.find(".//p[1]"),
-                    [xml.find(".//xref[1]"),
-                     xml.find(".//xref[2]")]),
-                 ],
-        }
-        self.assertEqual(expected, result)
-
-    def test_any_xref_parent_nodes_returns_two_parents_and_six_children(self):
-        text = (
-            '<article>'
-            '<body><p>'
-            '<xref ref-type="bibr" rid="B01">1</xref>'
-            '-<xref ref-type="bibr" rid="B02">2</xref>'
-            '<xref ref-type="bibr" rid="B05">5</xref>'
-            '-<xref ref-type="bibr" rid="B08">8</xref>'
-            '<xref ref-type="fig" rid="f01">1</xref>'
-            '-<xref ref-type="fig" rid="f02">2</xref>'
-            '</p></body>'
-            '</article>'
-        )
-        xml, error = xml_utils.load_xml(text)
-        a = Article(xml, "nome")
-        result = a.any_xref_parent_nodes
-        expected = {
-            "bibr":
-                [(xml.find(".//p[1]"),
-                    [xml.find(".//xref[1]"),
-                     xml.find(".//xref[2]"),
-                     xml.find(".//xref[3]"),
-                     xml.find(".//xref[4]"),
-                     ]),
-                 ],
-            "fig":
-                [(xml.find(".//p[1]"),
-                    [xml.find(".//xref[5]"),
-                     xml.find(".//xref[6]")]),
-                 ],
-        }
         self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_article.py
+++ b/src/scielo/bin/xml/tests/test_article.py
@@ -29,3 +29,89 @@ class TestArticle(TestCase):
         result = a.is_bibr_xref_number
         expected = False
         self.assertEqual(expected, result)
+
+    def test_is_bibr_xref_number_returns_false_for_sup_a1(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>(a1)</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.is_bibr_xref_number
+        expected = False
+        self.assertEqual(expected, result)
+
+    def test_any_xref_ranges_returns_dict_bibr_as_key_and_empty_list_as_value(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>(a1)</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_ranges
+        expected = {"bibr": []}
+        self.assertEqual(expected, result)
+
+    def test_any_xref_ranges_returns_dict_bibr_as_key_and_empty_list_as_value_because_it_is_not_a_range(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>(a1)</sup></xref>'
+            '-<xref ref-type="bibr" rid="B01"><sup>(a1)</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_ranges
+        expected = {"bibr": []}
+        self.assertEqual(expected, result)
+
+    def test_any_xref_ranges_returns_dict_bibr_as_key_and_one_item_list(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>1</sup></xref>'
+            '-<xref ref-type="bibr" rid="B02"><sup>2</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_ranges
+        expected = {
+            "bibr":
+            [[1, 2, xml.find(".//xref[1]"), xml.find(".//xref[2]")]]}
+        self.assertEqual(expected, result)
+
+    def test_any_xref_ranges_returns_dict_with_two_items(self):
+        text = (
+            '<article>'
+            '<body><p>'
+            '<xref ref-type="bibr" rid="B01"><sup>1</sup></xref>'
+            '-<xref ref-type="bibr" rid="B02"><sup>2</sup></xref>'
+            '<xref ref-type="bibr" rid="B05"><sup>5</sup></xref>'
+            '-<xref ref-type="bibr" rid="B08"><sup>8</sup></xref>'
+            '<xref ref-type="fig" rid="f01"><sup>1</sup></xref>'
+            '-<xref ref-type="fig" rid="f02"><sup>2</sup></xref>'
+            '</p></body>'
+            '</article>'
+        )
+        xml, error = xml_utils.load_xml(text)
+        a = Article(xml, "nome")
+        result = a.any_xref_ranges
+        expected = {
+            "bibr":
+                [[1, 2, xml.find(".//xref[1]"), xml.find(".//xref[2]")],
+                 [5, 8, xml.find(".//xref[3]"), xml.find(".//xref[4]")],
+                ],
+            "fig":
+                [[1, 2, xml.find(".//xref[5]"), xml.find(".//xref[6]")]]
+        }
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_article_content_validations.py
+++ b/src/scielo/bin/xml/tests/test_article_content_validations.py
@@ -303,6 +303,10 @@ class TestArticleContentValidationXref(TestCase):
         result = acv.missing_xref_list
         self.assertEqual("[ERROR]", result[0][1])
         self.assertIn("3-2 (B03-B02)", result[0][2])
+        self.assertEqual(
+            '<xref ref-type="bibr" rid="B03">3</xref>-'
+            '<xref ref-type="bibr" rid="B02">2</xref>',
+            result[0][3])
 
     def test_missing_xref_returns_empty_list_because_there_is_not_range(self):
         text = """<article><body>

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -618,3 +618,25 @@ class TestSuitableXML(TestCase):
             )
             self.assertIsNone(suitable_xml.xml_error)
 
+
+class TestNodeText(TestCase):
+
+    def test_node_text_returns_bold_wrapped_by_parentheses(self):
+        text = """<root>
+            <p>Texto <xref><sup>(<bold>bold</bold>)</sup></xref></p>
+            </root>"""
+        expected = "(bold)"
+        xml = xml_utils.etree.fromstring(text)
+        result = xml_utils.node_text(xml.find(".//xref"))
+        self.assertEqual(expected, result)
+
+    def test_node_text_returns_all_inner_texts_of_a_given_tag_as_str(self):
+        text = """<root>
+            <p>Texto <kmjmkl><italic><bold>bold</bold></italic> 
+            anady <k>adla</k> fuem lad</kmjmkl> fladjfajf;adjf;f</p>
+            </root>"""
+        expected = """Texto bold 
+            anady adla fuem lad fladjfajf;adjf;f"""
+        xml = xml_utils.etree.fromstring(text)
+        result = xml_utils.node_text(xml.find(".//p"))
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a validação de intervalos de citações. No texto do documento, em alguns casos há uma citação no seguinte formato `m-n`, onde `m` é o início e `n` é o final. Exemplos: intervalo de referências `3-5`, intervalo de figuras Fig `4-7`. A correção está relacionada com o padrão Autor, ano que estava sendo validado erroneamente como se fosse um intervalo:

```xml
<p><xref ref-type="bibr" rid="B68">Willems (1878</xref>-1885), de P. <xref ref-type="bibr" rid="B39">Frezza (1938</xref>
), pero sobre todo, a los de P. Catalano (1974) y F. de Martino (1972-1975).
</p>
```
#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Use o pacote em anexo.
[tk3286_xref_range.zip](https://github.com/scieloorg/PC-Programs/files/4898589/tk3286_xref_range.zip)

Execute o xpm:
```python xml_package_maker.py <pasta do pacote>```

Observe o relatório, abra a aba "Validações Individuais".
Na coluna mais à direita, clique no link "Validações de conteúdo" de cada documento.
Role a tela para visualizar o relatório.

Para o documento com final `-97.xml`, não existe mais a mensagem de erro quanto ao intervalo.
Para o documento com final `-fake.xml`, há a mensagem de erro quanto ao intervalo.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Antes:

<img width="877" alt="Captura de Tela 2020-07-08 às 16 12 07" src="https://user-images.githubusercontent.com/505143/87073468-d603ac00-c1f3-11ea-8dd0-8436a12a7326.png">

Depois:
<img width="882" alt="Captura de Tela 2020-07-09 às 12 31 44" src="https://user-images.githubusercontent.com/505143/87073477-d8fe9c80-c1f3-11ea-8bf8-b19ac6f58913.png">

#### Quais são tickets relevantes?
#3286

### Referências
n/a
