### PR TITLE
Corrige log de mensagem de email enviado com resultado da conversão

### DIFF
--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -225,7 +225,7 @@ class Reception(object):
             mail_subject, mail_content = mail_info
             self.mailer.mail_results(pkg_name, mail_subject, mail_content)
         else:
-            logger.info(pkg_name, mail_info)
+            logger.info('Package "%s" mail - "%s"', pkg_name, mail_info)
 
     def _update_website_files(self, package_name, acron, issue_id):
         if self.transfer:


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige log de mensagem de email enviado com resultado da conversão, evitando traceback de erro por conta da formatação do log.

#### Onde a revisão poderia começar?
Em `src/scielo/bin/xml/prodtools/xc.py`

#### Como este poderia ser testado manualmente?
1. Configure o XC, desabilitando o envio de e-mails, definindo a variável `EMAIL_SERVICE_STATUS` com `off`;
2. Converta um pacote SPS executando o comando `scieloxcserver <colecao>`;
3. A conversão deve finalizar com sucesso e o log da mensagem de resultado da conversão feito sem erro de formatação [1]

#### Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
o revisor a fim de facilitar o entendimento da funcionalidade.

### Screenshots
[1] - Log da mensagem sem erro

<img width="1654" alt="Screen Shot 2020-07-10 at 09 07 47" src="https://user-images.githubusercontent.com/18053487/87153016-1f540a00-c28d-11ea-83cc-dba88a55aad8.png">

#### Quais são tickets relevantes?
#3310

### Referências
.