### PR TITLE
Bloqueia documentos em que há <xref/> sem o atributo rid

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -351,11 +351,9 @@ class ContribXML(object):
             for contrib_id in self.contrib_id_items:
                 c.contrib_id[contrib_id.attrib.get('contrib-id-type')] = contrib_id.value
             c.role = self.node.get('contrib-type')
-            for xref in self.xref_items:
-                if xref is not None:
-                    text, attribs = xref
-                    if attribs.get('ref-type') == 'aff':
-                        c.xref.append(attribs.get('rid'))
+            for text, attribs in self.xref_items:
+                if attribs.get('ref-type') == 'aff' and attribs.get('rid'):
+                    c.xref.append(attribs.get('rid'))
             return c
 
     @property

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -335,7 +335,7 @@ class ContribXML(object):
 
     @property
     def anonymous_author(self):
-        if self.node.tag == 'anonymous':
+        if self.node.tag == 'anonymous' or self.node.find(".//anonymous") is not None:
             return AnonymousAuthor('anonymous')
 
     @property
@@ -365,14 +365,14 @@ class ContribXML(object):
             return c
 
     def contrib(self, role=None):
-        if self._contrib is None:
-            self._contrib = self.person_author
-            if self._contrib is None:
-                self._contrib = self.corp_author
-            if self._contrib is None:
-                self._contrib = self.anonymous_author
-            if self._contrib is not None and role is not None:
-                self._contrib.role = role
+        self._contrib = (
+            self._contrib or
+            self.person_author or
+            self.corp_author or
+            self.anonymous_author
+        )
+        if self._contrib and role:
+            self._contrib.role = role
         return self._contrib
 
 

--- a/src/scielo/bin/xml/prodtools/db/xc_models.py
+++ b/src/scielo/bin/xml/prodtools/db/xc_models.py
@@ -306,7 +306,7 @@ class ArticleRecords(object):
             new['s'] = surname_and_suffix
             new['p'] = item.prefix
             new['r'] = attributes.normalize_role(item.role)
-            new['1'] = ' '.join(item.xref)
+            new['1'] = ' '.join([item_valor for item_valor in item.xref if item_valor])
             new['k'] = item.contrib_id.get('orcid')
             new['l'] = item.contrib_id.get('lattes')
             self._metadata['10'].append(new)

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1311,18 +1311,15 @@ class ArticleContentValidation(object):
                             validation_status.STATUS_FATAL_ERROR,
                             _('Element related to `xref[@rid="{}"]` is required. ').format(xref_rid),
                             xref_xml))
-                if element_names is None:
-                    # no need to validate
-                    valid = True
-                if tag in element_names:
-                    valid = True
-                if tag not in element_names:
+                if tag and element_names and tag not in element_names:
                     reftypes = [
                         reftype
                         for reftype, _element_names in attributes.REFTYPE_AND_TAG_ITEMS.items()
                         if tag in _element_names]
 
-                    _msg = _('Unmatched {value} and {label}: {value1} is valid for {label1}, and {value2} is valid for {label2}').format(
+                    _msg = _('Unmatched {value} and {label}: '
+                             '{value1} is valid for {label1}, '
+                             'and {value2} is valid for {label2}').format(
                         value='@ref-type (' + xref_type + ')',
                         label=tag,
                         value1='xref[@ref-type="' + xref_type + '"]',
@@ -1330,15 +1327,6 @@ class ArticleContentValidation(object):
                         value2='|'.join(reftypes),
                         label2=tag + '/@ref-type'
                         )
-                    #_msg = _('Unmatched')
-                    #_msg += ' @ref-type (' + xref_type + ')'
-                    #_msg += _(' and ') + tag + ': '
-                    #_msg += 'xref[@ref-type="' + xref_type + '"] '
-                    #_msg += _('is for') + ' ' + ' | '.join(elements)
-                    #_msg += _(' and ') + _('valid values of') + ' @ref-type ' + _('of') + ' '
-                    #_msg += tag + ' ' + _('are') + ' '
-                    #_msg += '|'.join(reftypes)
-
                     message.append(
                         ('xref/@rid',
                             validation_status.STATUS_FATAL_ERROR, _msg))

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1281,31 +1281,34 @@ class ArticleContentValidation(object):
             for node in self.article.elements_which_has_id_attribute
             if node.attrib.get('id')}
 
-        for xref in self.article.xref_nodes:
-            if xref['rid'] is None:
+        for xref in self.article.tree.findall(".//xref"):
+            xref_rid = xref.get("rid")
+            xref_type = xref.get("ref-type")
+            xref_xml = xml_utils.tostring(xref)
+
+            if not xref_rid:
                 message.append(
                     ('xref/@rid',
                         validation_status.STATUS_FATAL_ERROR,
                         _('{label} is required. ').format(
-                            label='@rid'), xref['xml']))
-            if xref['ref-type'] is None:
+                            label='@rid'), xref_xml))
+            if not xref_type:
                 message.append(
                     ('xref/@ref-type',
                         validation_status.STATUS_ERROR,
                         _('{label} is required. ').format(
-                            label='@ref-type'), xref['xml']))
-            if xref['rid'] is not None and xref['ref-type'] is not None:
-                elements = attributes.REFTYPE_AND_TAG_ITEMS.get(
-                    xref['ref-type'])
-                tag = id_and_elem_name.get(xref['rid'])
+                            label='@ref-type'), xref_xml))
+            if xref_rid and xref_type:
+                elements = attributes.REFTYPE_AND_TAG_ITEMS.get(xref_type)
+                tag = id_and_elem_name.get(xref_rid)
                 if tag is None:
                     message.append(
                         ('xref/@rid',
                             validation_status.STATUS_FATAL_ERROR,
                             _('{label} is required. ').format(
-                                label=xref['ref-type'] + '[@id=' +
-                                xref['rid'] + ']'),
-                            xref['xml']))
+                                label=xref_type + '[@id=' +
+                                xref_rid + ']'),
+                            xref_xml))
                 elif elements is None:
                     # no need to validate
                     valid = True
@@ -1318,17 +1321,17 @@ class ArticleContentValidation(object):
                         if tag in _elements]
 
                     _msg = _('Unmatched {value} and {label}: {value1} is valid for {label1}, and {value2} is valid for {label2}').format(
-                        value='@ref-type (' + xref['ref-type'] + ')',
+                        value='@ref-type (' + xref_type + ')',
                         label=tag,
-                        value1='xref[@ref-type="' + xref['ref-type'] + '"]',
+                        value1='xref[@ref-type="' + xref_type + '"]',
                         label1=' | '.join(elements),
                         value2='|'.join(reftypes),
                         label2=tag + '/@ref-type'
                         )
                     #_msg = _('Unmatched')
-                    #_msg += ' @ref-type (' + xref['ref-type'] + ')'
+                    #_msg += ' @ref-type (' + xref_type + ')'
                     #_msg += _(' and ') + tag + ': '
-                    #_msg += 'xref[@ref-type="' + xref['ref-type'] + '"] '
+                    #_msg += 'xref[@ref-type="' + xref_type + '"] '
                     #_msg += _('is for') + ' ' + ' | '.join(elements)
                     #_msg += _(' and ') + _('valid values of') + ' @ref-type ' + _('of') + ' '
                     #_msg += tag + ' ' + _('are') + ' '

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1289,13 +1289,13 @@ class ArticleContentValidation(object):
             if not xref_rid:
                 message.append(
                     ('xref/@rid',
-                        validation_status.STATUS_FATAL_ERROR,
+                        validation_status.STATUS_BLOCKING_ERROR,
                         _('{label} is required. ').format(
                             label='@rid'), xref_xml))
             if not xref_type:
                 message.append(
                     ('xref/@ref-type',
-                        validation_status.STATUS_ERROR,
+                        validation_status.STATUS_FATAL_ERROR,
                         _('{label} is required. ').format(
                             label='@ref-type'), xref_xml))
             if xref_rid and xref_type:
@@ -1308,7 +1308,7 @@ class ArticleContentValidation(object):
                     # não há elemento cujo `@id` é igual a `@rid`
                     message.append(
                         ('xref/@rid',
-                            validation_status.STATUS_FATAL_ERROR,
+                            validation_status.STATUS_BLOCKING_ERROR,
                             _('Element related to `xref[@rid="{}"]` is required. ').format(xref_rid),
                             xref_xml))
                 if tag and element_names and tag not in element_names:

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1444,19 +1444,6 @@ class ArticleContentValidation(object):
         return message
 
     @property
-    def xref_rid_and_text(self):
-        message = []
-        for xref_node in self.article.xref_nodes:
-            rid = xref_node['rid']
-            if rid is not None and xref_node['xml'] is not None:
-                if rid[1:] not in xref_node['xml']:
-                    items = []
-                    items.append(('@rid', rid))
-                    items.append(('xref', xref_node['xml']))
-                    message.append(('xref', validation_status.STATUS_WARNING, data_validations.invalid_labels_and_values(items)))
-        return message
-
-    @property
     def svg(self):
         messages = []
         for href in self.article.hrefs:

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1299,7 +1299,9 @@ class ArticleContentValidation(object):
                         _('{label} is required. ').format(
                             label='@ref-type'), xref_xml))
             if xref_rid and xref_type:
-                elements = attributes.REFTYPE_AND_TAG_ITEMS.get(xref_type)
+                # para `xref_type`, retorna os nomes de elementos deste tipo
+                # por exemplo, para ref-type='table', retorna ['table-wrap']
+                element_names = attributes.REFTYPE_AND_TAG_ITEMS.get(xref_type)
                 tag = id_and_elem_name.get(xref_rid)
                 if tag is None:
                     message.append(
@@ -1309,22 +1311,22 @@ class ArticleContentValidation(object):
                                 label=xref_type + '[@id=' +
                                 xref_rid + ']'),
                             xref_xml))
-                elif elements is None:
+                elif element_names is None:
                     # no need to validate
                     valid = True
-                elif tag in elements:
+                elif tag in element_names:
                     valid = True
-                elif tag not in elements:
+                elif tag not in element_names:
                     reftypes = [
                         reftype
-                        for reftype, _elements in attributes.REFTYPE_AND_TAG_ITEMS.items()
-                        if tag in _elements]
+                        for reftype, _element_names in attributes.REFTYPE_AND_TAG_ITEMS.items()
+                        if tag in _element_names]
 
                     _msg = _('Unmatched {value} and {label}: {value1} is valid for {label1}, and {value2} is valid for {label2}').format(
                         value='@ref-type (' + xref_type + ')',
                         label=tag,
                         value1='xref[@ref-type="' + xref_type + '"]',
-                        label1=' | '.join(elements),
+                        label1=' | '.join(element_names),
                         value2='|'.join(reftypes),
                         label2=tag + '/@ref-type'
                         )

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1311,12 +1311,12 @@ class ArticleContentValidation(object):
                             validation_status.STATUS_FATAL_ERROR,
                             _('Element related to `xref[@rid="{}"]` is required. ').format(xref_rid),
                             xref_xml))
-                elif element_names is None:
+                if element_names is None:
                     # no need to validate
                     valid = True
-                elif tag in element_names:
+                if tag in element_names:
                     valid = True
-                elif tag not in element_names:
+                if tag not in element_names:
                     reftypes = [
                         reftype
                         for reftype, _element_names in attributes.REFTYPE_AND_TAG_ITEMS.items()

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1276,25 +1276,46 @@ class ArticleContentValidation(object):
     def validate_xref_reftype(self):
         message = []
 
-        id_and_elem_name = {node.attrib.get('id'): node.tag for node in self.article.elements_which_has_id_attribute if node.attrib.get('id') is not None}
+        id_and_elem_name = {
+            node.attrib.get('id'): node.tag
+            for node in self.article.elements_which_has_id_attribute
+            if node.attrib.get('id')}
 
         for xref in self.article.xref_nodes:
             if xref['rid'] is None:
-                message.append(('xref/@rid', validation_status.STATUS_FATAL_ERROR, _('{label} is required. ').format(label='@rid'), xref['xml']))
+                message.append(
+                    ('xref/@rid',
+                        validation_status.STATUS_FATAL_ERROR,
+                        _('{label} is required. ').format(
+                            label='@rid'), xref['xml']))
             if xref['ref-type'] is None:
-                message.append(('xref/@ref-type', validation_status.STATUS_ERROR, _('{label} is required. ').format(label='@ref-type'), xref['xml']))
+                message.append(
+                    ('xref/@ref-type',
+                        validation_status.STATUS_ERROR,
+                        _('{label} is required. ').format(
+                            label='@ref-type'), xref['xml']))
             if xref['rid'] is not None and xref['ref-type'] is not None:
-                elements = attributes.REFTYPE_AND_TAG_ITEMS.get(xref['ref-type'])
+                elements = attributes.REFTYPE_AND_TAG_ITEMS.get(
+                    xref['ref-type'])
                 tag = id_and_elem_name.get(xref['rid'])
                 if tag is None:
-                    message.append(('xref/@rid', validation_status.STATUS_FATAL_ERROR, _('{label} is required. ').format(label=xref['ref-type'] + '[@id=' + xref['rid'] + ']'), xref['xml']))
+                    message.append(
+                        ('xref/@rid',
+                            validation_status.STATUS_FATAL_ERROR,
+                            _('{label} is required. ').format(
+                                label=xref['ref-type'] + '[@id=' +
+                                xref['rid'] + ']'),
+                            xref['xml']))
                 elif elements is None:
                     # no need to validate
                     valid = True
                 elif tag in elements:
                     valid = True
                 elif tag not in elements:
-                    reftypes = [reftype for reftype, _elements in attributes.REFTYPE_AND_TAG_ITEMS.items() if tag in _elements]
+                    reftypes = [
+                        reftype
+                        for reftype, _elements in attributes.REFTYPE_AND_TAG_ITEMS.items()
+                        if tag in _elements]
 
                     _msg = _('Unmatched {value} and {label}: {value1} is valid for {label1}, and {value2} is valid for {label2}').format(
                         value='@ref-type (' + xref['ref-type'] + ')',
@@ -1313,7 +1334,9 @@ class ArticleContentValidation(object):
                     #_msg += tag + ' ' + _('are') + ' '
                     #_msg += '|'.join(reftypes)
 
-                    message.append(('xref/@rid', validation_status.STATUS_FATAL_ERROR, _msg))
+                    message.append(
+                        ('xref/@rid',
+                            validation_status.STATUS_FATAL_ERROR, _msg))
         return message
 
     @property

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -1302,14 +1302,14 @@ class ArticleContentValidation(object):
                 # para `xref_type`, retorna os nomes de elementos deste tipo
                 # por exemplo, para ref-type='table', retorna ['table-wrap']
                 element_names = attributes.REFTYPE_AND_TAG_ITEMS.get(xref_type)
+                # encontra o nome do elemento cujo `@id` é igual a `@rid`
                 tag = id_and_elem_name.get(xref_rid)
                 if tag is None:
+                    # não há elemento cujo `@id` é igual a `@rid`
                     message.append(
                         ('xref/@rid',
                             validation_status.STATUS_FATAL_ERROR,
-                            _('{label} is required. ').format(
-                                label=xref_type + '[@id=' +
-                                xref_rid + ']'),
+                            _('Element related to `xref[@rid="{}"]` is required. ').format(xref_rid),
                             xref_xml))
                 elif element_names is None:
                     # no need to validate

--- a/src/scielo/bin/xml/tests/test_article_contrib.py
+++ b/src/scielo/bin/xml/tests/test_article_contrib.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+
+from lxml import etree
+from prodtools.data.article import ContribXML
+
+
+class TestContribXML(TestCase):
+
+    def create(self, text):
+        xml = etree.fromstring(text)
+        return ContribXML(xml)
+
+    def test_contrib_xml_returns_person_author_xref_is_a01(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-1709-3448</contrib-id>
+          <name>
+            <surname>Salvalaggio</surname>
+            <given-names>Adriana Cologni</given-names>
+          </name>
+          <xref ref-type="aff" rid="a01">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        """
+        expected = ["a01"]
+        c = self.create(text)
+        result = c.contrib().xref
+        self.assertEqual(expected, result)
+
+    def test_contrib_xml_returns_person_author_xref_is_empty_list(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-1709-3448</contrib-id>
+          <name>
+            <surname>Salvalaggio</surname>
+            <given-names>Adriana Cologni</given-names>
+          </name>
+          <xref ref-type="aff">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        """
+        expected = []
+        c = self.create(text)
+        result = c.contrib().xref
+        self.assertEqual(expected, result)

--- a/src/scielo/bin/xml/tests/test_article_contrib.py
+++ b/src/scielo/bin/xml/tests/test_article_contrib.py
@@ -1,14 +1,14 @@
 from unittest import TestCase
 
 from lxml import etree
-from prodtools.data.article import ContribXML
+from prodtools.data import article
 
 
 class TestContribXML(TestCase):
 
     def create(self, text):
         xml = etree.fromstring(text)
-        return ContribXML(xml)
+        return article.ContribXML(xml)
 
     def test_contrib_xml_returns_person_author_xref_is_a01(self):
         text = """
@@ -47,3 +47,54 @@ class TestContribXML(TestCase):
         c = self.create(text)
         result = c.contrib().xref
         self.assertEqual(expected, result)
+
+    def test_contrib_returns_person_author(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-1709-3448</contrib-id>
+          <name>
+            <surname>Salvalaggio</surname>
+            <given-names>Adriana Cologni</given-names>
+          </name>
+          <xref ref-type="aff">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        """
+        c = self.create(text)
+        result = c.contrib()
+        self.assertIsInstance(result, article.PersonAuthor)
+
+    def test_contrib_returns_None(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+        </contrib>
+        """
+        c = self.create(text)
+        result = c.contrib()
+        self.assertIsNone(result)
+
+    def test_contrib_returns_anonymous(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+          <anonymous/>
+        </contrib>
+        """
+        c = self.create(text)
+        result = c.contrib()
+        self.assertIsInstance(result, article.AnonymousAuthor)
+
+    def test_contrib_returns_corp_author(self):
+        text = """
+        <contrib xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
+          <collab><name>Institution</name></collab>
+        </contrib>
+        """
+        c = self.create(text)
+        result = c.contrib()
+        self.assertIsInstance(result, article.CorpAuthor)
+


### PR DESCRIPTION
#### O que esse PR faz?
Bloqueia documentos em que há <xref/> sem o atributo rid e em consequência resolve problema da exceção mencionada em #3311

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Crie um documento em que haja `<xref/>` sem `@rid` ou use o pacote em anexo. ([tk3311.zip](https://github.com/scieloorg/PC-Programs/files/4903249/tk3311.zip))
Execute o XC:

```python xml_converter.py <pasta do pacote>```

Verifique que a exceção não ocorre mais.

#### Algum cenário de contexto que queira dar?
A exceção ocorre ao preparar os dados para a base ISIS, mas pode-se verificar as modificações também nos relatórios, mesmo executando o XPM.
```python xml_package_maker.py <pasta do pacote>```
A exceção ocorria porque o XML continha pelo menos 1 xref sem `@rid` e ao tentar concatenar elementos `None` de uma lista o erro ocorria.
A correção envolveu:
- modificação ao armazenar o valor ausente para `xref/@rid`
- modificação ao preparar os dados para a base ISIS
- explicitação do erro no XML

### Screenshots
Modificações nos relatórios:

176-fake.xml
<img width="1174" alt="Captura de Tela 2020-07-10 às 10 06 07" src="https://user-images.githubusercontent.com/505143/87158881-cd17e680-c296-11ea-8184-200694d083c3.png">

240.xml
<img width="1174" alt="Captura de Tela 2020-07-10 às 10 04 47" src="https://user-images.githubusercontent.com/505143/87158889-d0ab6d80-c296-11ea-9dfe-f9f70c857c52.png">

#### Quais são tickets relevantes?
#3311

### Referências
n/a
