### PR TITLE
Altera gravação de relatório para copiar XMLs somente se convertidos

### DIFF
--- a/src/scielo/bin/xml/prodtools/validations/reports_maker.py
+++ b/src/scielo/bin/xml/prodtools/validations/reports_maker.py
@@ -333,10 +333,11 @@ class CollectionAssetsInReport(object):
         if self.web_url:
             # se há o site remoto, os xml não estão acessíveis mesmo
             # existindo em bases/xml, por isso,
-            # copia os xml para htdocs/reports/<acron>/<issue>/
-            for fname in os.listdir(self.xml_path):
-                file_path = os.path.join(self.xml_path, fname)
-                shutil.copy(file_path, self.report_path)
+            # copia os xmls para htdocs/reports/<acron>/<issue>/, se existirem
+            if os.path.isdir(self.xml_path):
+                for fname in os.listdir(self.xml_path):
+                    file_path = os.path.join(self.xml_path, fname)
+                    shutil.copy(file_path, self.report_path)
 
     @property
     def result_path(self):

--- a/src/scielo/bin/xml/tests/test_reports_maker.py
+++ b/src/scielo/bin/xml/tests/test_reports_maker.py
@@ -1,3 +1,6 @@
+import tempfile
+import shutil
+import pathlib
 from unittest import TestCase
 
 from prodtools.validations.reports_maker import (
@@ -315,3 +318,78 @@ class TestCollectionAssetsInReportForRemoteWebsite(TestCase):
         self.assertEqual(
             '/scielo/serial_path/acron/issue_label/base_xml/base_source',
             self.data.serial_base_xml_path)
+
+
+class TestCollectionAssetsInReportValidateSaveReport(TestCase):
+
+    def setUp(self):
+        self.serial_path = tempfile.mkdtemp()
+        self.web_app_path = tempfile.mkdtemp()
+        self.data = CollectionAssetsInReport(
+            "acron", "issue_label",
+            self.serial_path,
+            self.web_app_path,
+            "https://qa.scielo.br",
+        )
+
+    def tearDown(self):
+        self.serial_path = tempfile.mkdtemp()
+        self.web_app_path = tempfile.mkdtemp()
+
+    def test_report_path(self):
+        expected = str(
+            pathlib.Path(self.web_app_path) / 'htdocs/reports/acron/issue_label'
+        )
+        self.assertEqual(expected, self.data.report_path)
+
+    def test_serial_report_path(self):
+        expected = str(
+            pathlib.Path(self.serial_path) / 'acron/issue_label/base_xml/base_reports'
+        )
+        self.assertEqual(expected, self.data.serial_report_path)
+
+    def test_xml_path(self):
+        expected = str(
+            pathlib.Path(self.web_app_path) / 'bases/xml/acron/issue_label'
+        )
+        self.assertEqual(expected, self.data.xml_path)
+
+    def test_save_report_saves_in_serial_report_path(self):
+        report_text = "<html><body><p>Teste</p></body></html>"
+        with tempfile.TemporaryDirectory() as temp_dir_path:
+            report_path = pathlib.Path(temp_dir_path) / "report.html"
+            report_path.write_text(report_text)
+            self.data.save_report(str(report_path))
+            path_result = pathlib.Path(self.data.serial_report_path) / "report.html"
+            self.assertEqual(path_result.read_text(), report_text)
+
+    def test_save_report_without_converted_xml(self):
+        # Garante que dir report_path existe
+        pathlib.Path(self.data.report_path).mkdir(parents=True, exist_ok=True)
+        # Grava fake report
+        report_path = pathlib.Path(self.web_app_path) / "report.html"
+        report_path.write_text("<html><body><p>Teste</p></body></html>")
+        # Grava fake XML
+        temp_dir_path = pathlib.Path(self.data.xml_path)
+        temp_dir_path.mkdir(parents=True, exist_ok=True)
+
+        self.data.save_report(str(report_path))
+        path_result = pathlib.Path(self.data.report_path) / "doc.xml"
+        self.assertFalse(path_result.exists())
+
+    def test_save_report_copy_converted_xml_to_remote(self):
+        # Garante que dir report_path existe
+        pathlib.Path(self.data.report_path).mkdir(parents=True, exist_ok=True)
+        # Grava fake report
+        report_path = pathlib.Path(self.web_app_path) / "report.html"
+        report_path.write_text("<html><body><p>Teste</p></body></html>")
+        # Grava fake XML
+        xml_text = "<article><body><p>Teste</p></body></article>"
+        temp_dir_path = pathlib.Path(self.data.xml_path)
+        temp_dir_path.mkdir(parents=True, exist_ok=True)
+        xml_path = temp_dir_path / "doc.xml"
+        xml_path.write_text(xml_text)
+
+        self.data.save_report(str(report_path))
+        path_result = pathlib.Path(self.data.report_path) / "doc.xml"
+        self.assertEqual(path_result.read_text(), xml_text)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige cópia de documentos XMLs para site remote na gravação do relatório de conversão em QA.  Se a após a conversão de um pacote SPS de um novo fascículo nenhum dos documentos for convertido com sucesso, `htdocs/reports/<acron>/<issue>/` não existirá. Então, é necessário verificar primeiro se o diretório existe para, assim, tentar copiar os XMLs.

#### Onde a revisão poderia começar?
Commit cac2f00

#### Como este poderia ser testado manualmente?
- Coloque um pacote no diretório de trabalho do XC que não tenha documentos a ser convertido. Pacote [1]
- Execute o XC
- O pacote não será convertido, o relatório de conversão será gerado sem problema e a aplicação não registrará erro
`FileNotFoundError: [Errno 2] No such file or directory:`

#### Algum cenário de contexto que queira dar?
Este problema foi detectado no ambiente de teste de migração.

### Anexo
[[1] - Pacote com erro na conversão](https://github.com/scieloorg/PC-Programs/files/4903249/tk3311.zip)

### Screenshots
n/a.

#### Quais são tickets relevantes?
#3284

### Referências
.

