### PR TITLE
Acrescenta dados do pacote no relatório para melhor rastreabilidade na integração com SPF

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -1086,13 +1086,13 @@ class ArticleXML(object):
                 return _doi.lower()
 
     @property
-    def doi_and_lang(self):
+    def doi_by_lang(self):
         r = []
         if self.doi:
             r = [(self.language, self.doi)]
         for translation in self.translations or []:
             doi = translation.findtext('.//article-id[@pub-id-type="doi"]') or ''
-            r.append((element_lang(translation), doi.lower()))
+            r.append((element_lang(translation), doi))
         return r
 
     @property

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -709,20 +709,26 @@ class ArticleXML(object):
     @property
     def dtd_version(self):
         if self.tree is not None:
-            if self.tree.find('.') is not None:
-                return self.tree.find('.').attrib.get('dtd-version')
+            return self.tree.find('.').attrib.get('dtd-version')
 
     @property
     def sps(self):
         if self.tree is not None:
-            if self.tree.find('.') is not None:
-                return self.tree.find('.').attrib.get('specific-use')
+            return self.tree.find('.').attrib.get('specific-use')
 
     @property
     def article_type(self):
         if self.tree is not None:
-            if self.tree.find('.') is not None:
-                return self.tree.find('.').attrib.get('article-type')
+            return self.tree.find('.').attrib.get('article-type')
+
+    @property
+    def article_types(self):
+        if self.tree is not None:
+            return (
+                (element_lang(node), node.get("article-type"))
+                for node in [self.tree.find('.')] + self.tree.xpath(
+                             ".//*[@article-type]")
+            )
 
     @property
     def body_words(self):

--- a/src/scielo/bin/xml/prodtools/db/xc_models.py
+++ b/src/scielo/bin/xml/prodtools/db/xc_models.py
@@ -327,7 +327,7 @@ class ArticleRecords(object):
         self._metadata['237'] = self.article.doi
         self._metadata['337'] = [
             {'l': lang, 'd': doi}
-            for lang, doi in self.article.doi_and_lang
+            for lang, doi in self.article.doi_by_lang
             if doi and lang
             ]
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -361,10 +361,10 @@ class ArticlesConversion(object):
         reason = conclusion.get("reason")
         update = conclusion.get("update")
 
-        action = _('will not be')
-        if update:
-            action = _('will be')
-        text = u'{status}: {issueid} {action} {result} {reason}'.format(status=status, issueid=self.acron_issue_label, result=result, reason=reason, action=action)
+        action = _('will be') if update else _('will not be')
+        action += " " + result
+
+        text = u'{status}: {issueid} {action} {reason}'.format(status=status, issueid=self.acron_issue_label, action=action, reason=reason)
         text = html_reports.p_message(_('converted') + ': ' + str(self.total_converted) + '/' + str(self.accepted_articles), False) + html_reports.p_message(text, False)
         return text
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -364,8 +364,13 @@ class ArticlesConversion(object):
         action = _('will be') if update else _('will not be')
         action += " " + result
 
-        text = u'{status}: {issueid} {action} {reason}'.format(status=status, issueid=self.acron_issue_label, action=action, reason=reason)
-        text = html_reports.p_message(_('converted') + ': ' + str(self.total_converted) + '/' + str(self.accepted_articles), False) + html_reports.p_message(text, False)
+        text = u'{status}: {issueid} {action} {reason}'.format(
+            status=status, issueid=self.acron_issue_label,
+            action=action, reason=reason)
+        text = html_reports.p_message(
+                _('converted') + ': ' +
+                str(self.total_converted) + '/' + str(self.accepted_articles),
+                False) + html_reports.p_message(text, False)
         return text
 
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -72,6 +72,35 @@ def xpm_version():
 
 
 class ArticlesConversion(object):
+    CONCLUSION = {
+        "rejected": {
+            "update": False,
+            "status": validation_status.STATUS_BLOCKING_ERROR,
+            "reason": "...",
+        },
+        "ignored": {
+            "update": False,
+            "status": validation_status.STATUS_BLOCKING_ERROR,
+            "reason": _('because there is no document allowed to convert. '),
+        },
+        "accepted": {
+            "update": True,
+            "status": validation_status.STATUS_WARNING,
+            "reason": _(' even though there are some fatal errors. '
+                        'Note: These errors must be fixed in order to have '
+                        'good quality of bibliometric indicators and '
+                        'services. '),
+        },
+        "approved": {
+            "update": True,
+            "status": validation_status.STATUS_OK,
+        },
+        "otherwise": {
+            "update": True,
+            "status": validation_status.STATUS_FATAL_ERROR,
+            "reason": _('because there are blocking errors in the package. ')
+        }
+    }
 
     def __init__(self, registered_issue_data, pkg, pkg_eval_result, create_windows_base, web_app_path, web_app_site):
         self.create_windows_base = create_windows_base
@@ -310,14 +339,12 @@ class ArticlesConversion(object):
     @property
     def conclusion_message(self):
         text = ''.join(self.error_messages)
-        app_site = self.web_app_site if self.web_app_site is not None else _('scielo web site')
+        app_site = self.web_app_site or _('scielo web site')
         status = ''
         result = _('updated/published on {app_site}').format(app_site=app_site)
         reason = ''
         update = True
         if self.xc_status == 'rejected':
-            update = False
-            status = validation_status.STATUS_BLOCKING_ERROR
             if self.accepted_articles > 0:
                 if self.total_not_converted > 0:
                     reason = _('because it is not complete ({value} were not converted). ').format(value=str(self.total_not_converted) + '/' + str(self.accepted_articles))

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -337,6 +337,20 @@ class ArticlesConversion(object):
         return r
 
     @property
+    def conclusion(self):
+        _conclusion = self.CONCLUSION.get(self.xc_status, "otherwise")
+        if self.xc_status == 'rejected':
+            if self.accepted_articles > 0:
+                if self.total_not_converted > 0:
+                    reason = _('because it is not complete ({value} were not converted). ').format(value=str(self.total_not_converted) + '/' + str(self.accepted_articles))
+                else:
+                    reason = _('because there are blocking errors in the package. ')
+            else:
+                reason = _('because there are blocking errors in the package. ')
+            _conclusion["reason"] = reason
+        return _conclusion
+
+    @property
     def conclusion_message(self):
         text = ''.join(self.error_messages)
         app_site = self.web_app_site or _('scielo web site')

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -369,6 +369,20 @@ class ArticlesConversion(object):
         return (html_reports.p_message(converted, False) +
                 html_reports.p_message(text, False))
 
+    @property
+    def spf_message(self):
+        if not self.sps_pkg_info:
+            return ""
+        ftp = ""
+        if self.sps_pkg_info.get("server"):
+            ftp = _("(FTP: {} | User: {})").format(
+                    self.sps_pkg_info.get("server"),
+                    self.sps_pkg_info.get("user", ''))
+        return html_reports.p_message(
+                _("[INFO] {} is available to SPF {}").format(
+                    self.sps_pkg_info.get("file"), ftp)
+            )
+
 
 class PkgProcessor(object):
 

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -357,21 +357,17 @@ class ArticlesConversion(object):
         result = _('updated/published on {app_site}').format(app_site=app_site)
 
         conclusion = self.conclusion
-        status = conclusion.get("status")
-        reason = conclusion.get("reason")
-        update = conclusion.get("update")
 
-        action = _('will be') if update else _('will not be')
-        action += " " + result
+        action = _('will be') if conclusion.get("update") else _('will not be')
 
         text = u'{status}: {issueid} {action} {reason}'.format(
-            status=status, issueid=self.acron_issue_label,
-            action=action, reason=reason)
-        text = html_reports.p_message(
-                _('converted') + ': ' +
-                str(self.total_converted) + '/' + str(self.accepted_articles),
-                False) + html_reports.p_message(text, False)
-        return text
+            issueid=self.acron_issue_label, action=action + " " + result,
+            **conclusion)
+
+        converted = "{}: {}/{}".format(_('converted'), self.total_converted,
+                                       self.accepted_articles)
+        return (html_reports.p_message(converted, False) +
+                html_reports.p_message(text, False))
 
 
 class PkgProcessor(object):

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -84,6 +84,7 @@ class ArticlesConversion(object):
         self.error_messages = []
         self.conversion_status = {}
         self.updated_scilista_items = None
+        self.sps_pkg_info = None
 
     def convert(self):
         self.updated_scilista_items = None
@@ -140,7 +141,8 @@ class ArticlesConversion(object):
             return None
 
         package_zip_name = "{}.zip".format(package_name.replace(" ", "_"))
-        exporter(self.pkg.package_folder.path, package_zip_name)
+        self.sps_pkg_info = exporter(
+            self.pkg.package_folder.path, package_zip_name)
 
     @property
     def aop_status(self):
@@ -356,7 +358,6 @@ class PkgProcessor(object):
         self.registered_issues_manager = xc_models.RegisteredIssuesManager(
             self.config, self.is_db_generation)
         self._pid_manager = None
-
 
     @property
     def export_documents_package(self):

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -354,31 +354,13 @@ class ArticlesConversion(object):
     def conclusion_message(self):
         text = ''.join(self.error_messages)
         app_site = self.web_app_site or _('scielo web site')
-        status = ''
         result = _('updated/published on {app_site}').format(app_site=app_site)
-        reason = ''
-        update = True
-        if self.xc_status == 'rejected':
-            if self.accepted_articles > 0:
-                if self.total_not_converted > 0:
-                    reason = _('because it is not complete ({value} were not converted). ').format(value=str(self.total_not_converted) + '/' + str(self.accepted_articles))
-                else:
-                    reason = _('because there are blocking errors in the package. ')
-            else:
-                reason = _('because there are blocking errors in the package. ')
-        elif self.xc_status == 'ignored':
-            update = False
-            reason = _('because there is no document allowed to convert. ')
-            status = validation_status.STATUS_BLOCKING_ERROR
-        elif self.xc_status == 'accepted':
-            status = validation_status.STATUS_WARNING
-            reason = _(' even though there are some fatal errors. Note: These errors must be fixed in order to have good quality of bibliometric indicators and services. ')
-        elif self.xc_status == 'approved':
-            status = validation_status.STATUS_OK
-            reason = ''
-        else:
-            status = validation_status.STATUS_FATAL_ERROR
-            reason = _('because there are blocking errors in the package. ')
+
+        conclusion = self.conclusion
+        status = conclusion.get("status")
+        reason = conclusion.get("reason")
+        update = conclusion.get("update")
+
         action = _('will not be')
         if update:
             action = _('will be')

--- a/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
+++ b/src/scielo/bin/xml/prodtools/processing/pkg_processors.py
@@ -342,7 +342,7 @@ class ArticlesConversion(object):
 
     @property
     def conclusion_message(self):
-        if hasattr(self, _conclusion_message):
+        if hasattr(self, '_conclusion_message'):
             return self._conclusion_message
 
         text = ''.join(self.error_messages)
@@ -361,7 +361,7 @@ class ArticlesConversion(object):
                                        self.accepted_articles)
         self._conclusion_message = (
                 html_reports.p_message(converted, False) +
-                html_reports.p_message(text, False) + self.sps_pkg_info)
+                html_reports.p_message(text, False) + self.spf_message)
         return self._conclusion_message
 
     @property
@@ -374,7 +374,7 @@ class ArticlesConversion(object):
                     self.sps_pkg_info.get("server"),
                     self.sps_pkg_info.get("user", ''))
         return html_reports.p_message(
-                _("[INFO] {} is available to SPF {}").format(
+                _("[INFO] {} is available for SPF {}").format(
                     self.sps_pkg_info.get("file"), ftp)
             )
 

--- a/src/scielo/bin/xml/prodtools/reports/html_reports.css
+++ b/src/scielo/bin/xml/prodtools/reports/html_reports.css
@@ -48,7 +48,7 @@ td {
 }
 .subtitle {
   margin: 5px;
-  font-size: 8pt;
+  font-size: 10pt;
   font-family: Verdana;
   color: #3D3832;
   background-color: #F0CEC2;
@@ -61,21 +61,21 @@ td {
 .element-table table {
    border: 1px solid gray;
    font-family: Courier;
-   font-size: 10;
+   font-size: 10pt;
    color: black;
    background-color: white;
 } 
 .element-table td {
    border: 1px solid gray;
    font-family: Courier;
-   font-size: 10;
+   font-size: 10pt;
    color: black;
    background-color: white;
 } 
 .element-table th {
    border: 1px solid gray;
    font-family: Courier;
-   font-size: 10;
+   font-size: 10pt;
    color: black;
    background-color: white;
 }
@@ -110,7 +110,7 @@ h5 {
 }
 .td_xml {
     color: #113F8C;
-    font-size: 7pt;
+    font-size: 9pt;
     font-family: Courier;
     word-wrap:break-word;
     width: 20%;
@@ -118,7 +118,7 @@ h5 {
 .validation_sheet {
    border: 1px dotted #8B85AB;
    font-family: "Verdana";
-   font-size: 8pt;
+   font-size: 10pt;
    color: black; 
    width: 100%;
    max-width: 1200px;
@@ -195,7 +195,7 @@ h5 {
 .sheet {
   border: 1px solid gray;
   font-family: "Verdana";
-  font-size: 10;
+  font-size: 10pt;
   color: black; 
   width: 100%;
   max-width: 1200px;
@@ -203,7 +203,7 @@ h5 {
 .sheet td {
   border: 1px solid gray;
    font-family: Courier;
-   font-size: 8pt;
+   font-size: 10pt;
    color: black;
    vertical-align: top;
    word-wrap:break-word;
@@ -272,7 +272,7 @@ h5 {
 .discret {
     font-family: Courier;
     color: gray;
-    font-size: 8pt;
+    font-size: 10pt;
 }
 .article-type {
     color: #ED146F;
@@ -408,7 +408,7 @@ h5 {
   word-wrap:break-word;
   margin: 5px;
   font-family: Verdana;
-  font-size: 8pt;
+  font-size: 10pt;
 } 
 .dbstatus td {
   border: 1px solid gray;
@@ -449,8 +449,9 @@ h5 {
 .report-section {
   margin-top: 50px;
 }
+/* fundo azulado */
 .pid {
-  color: #B38295;
+  color: white;
   background-color: #295876;
 }
 .aop-block {
@@ -460,6 +461,7 @@ h5 {
   margin-bottom: 35px;
   padding: 10px;
 }
+/* fundo avermelhado */
 .aop {
   color: white;
   background-color: #ED146F;

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -78,9 +78,7 @@ class Exporter(object):
             )
             shutil.move(zip_file_path, final_file_path)
 
-            if destination_path:
-                pass
-            elif ftp_configuration:
+            if not destination_path and ftp_configuration:
                 server, user, password, remote_path = ftp_configuration
                 self.export_by_ftp(final_file_path, server, user, password, remote_path)
 

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -81,6 +81,12 @@ class Exporter(object):
             if not destination_path and ftp_configuration:
                 server, user, password, remote_path = ftp_configuration
                 self.export_by_ftp(final_file_path, server, user, password, remote_path)
+                return {
+                    "file": os.path.join(
+                        remote_path, os.path.basename(final_file_path)),
+                    "ftp": server, "user": user,
+                }
+            return {"file": final_file_path}
 
     def zip(self, source_path, zip_filename):
         try:

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -69,16 +69,20 @@ class Exporter(object):
             return
 
         zip_file_path = self.zip(source_path, zip_filename)
-        if zip_file_path:
-            if destination_path:
-                final_file_path = self._preppend_time_to_destination_filename(
-                    destination_path, zip_file_path
-                )
-                shutil.move(zip_file_path, final_file_path)
 
+        if zip_file_path:
+            dest_path = destination_path or os.path.dirname(zip_file_path)
+
+            final_file_path = self._preppend_time_to_destination_filename(
+                dest_path, zip_file_path
+            )
+            shutil.move(zip_file_path, final_file_path)
+
+            if destination_path:
+                pass
             elif ftp_configuration:
                 server, user, password, remote_path = ftp_configuration
-                self.export_by_ftp(zip_file_path, server, user, password, remote_path)
+                self.export_by_ftp(final_file_path, server, user, password, remote_path)
 
     def zip(self, source_path, zip_filename):
         try:

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -71,15 +71,12 @@ class Exporter(object):
             if destination_path:
                 if not os.path.isdir(destination_path):
                     os.makedirs(destination_path)
-                if ftp_configuration:
-                    shutil.copy(zip_file_path, destination_path)
-                else:
-                    final_file_path = self._preppend_time_to_destination_filename(
-                        destination_path, zip_file_path
-                    )
-                    shutil.move(zip_file_path, final_file_path)
+                final_file_path = self._preppend_time_to_destination_filename(
+                    destination_path, zip_file_path
+                )
+                shutil.move(zip_file_path, final_file_path)
 
-            if ftp_configuration:
+            elif ftp_configuration:
                 server, user, password, remote_path = ftp_configuration
                 self.export_by_ftp(zip_file_path, server, user, password, remote_path)
 

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -60,7 +60,7 @@ class Exporter(object):
         _, file_name = os.path.split(file_path)
         return os.path.join(destination_dir, "%s_%s" % (data, file_name))
 
-    def export(self, files_path, zip_filename):
+    def export(self, source_path, zip_filename):
         destination_path = self.copy_configuration
         ftp_configuration = self.ftp_configuration
 
@@ -68,7 +68,7 @@ class Exporter(object):
             exp_logger.info("Exporter: Missing Configuration")
             return
 
-        zip_file_path = self.zip(files_path, zip_filename)
+        zip_file_path = self.zip(source_path, zip_filename)
         if zip_file_path:
             if destination_path:
                 final_file_path = self._preppend_time_to_destination_filename(
@@ -80,7 +80,7 @@ class Exporter(object):
                 server, user, password, remote_path = ftp_configuration
                 self.export_by_ftp(zip_file_path, server, user, password, remote_path)
 
-    def zip(self, files_path, zip_filename):
+    def zip(self, source_path, zip_filename):
         try:
             dest_path = tempfile.mkdtemp()
         except IOError:
@@ -90,9 +90,9 @@ class Exporter(object):
             try:
                 with zipfile.ZipFile(zip_file_path, 'w') as zipf:
                     exp_logger.info(
-                        "Create %s from %s" % (zip_file_path, files_path))
-                    for item in os.listdir(files_path):
-                        file_path = os.path.join(files_path, item)
+                        "Create %s from %s" % (zip_file_path, source_path))
+                    for item in os.listdir(source_path):
+                        file_path = os.path.join(source_path, item)
                         zipf.write(file_path, arcname=item)
             except IOError:
                 exp_logger.info(

--- a/src/scielo/bin/xml/prodtools/utils/exporter.py
+++ b/src/scielo/bin/xml/prodtools/utils/exporter.py
@@ -32,6 +32,8 @@ class Exporter(object):
     def copy_configuration(self):
         try:
             destination_path = self._data["destination_path"]
+            if not os.path.isdir(destination_path):
+                os.makedirs(destination_path)
         except KeyError:
             exp_logger.info("Exporter: Missing Destination Configuration")
         else:
@@ -69,8 +71,6 @@ class Exporter(object):
         zip_file_path = self.zip(files_path, zip_filename)
         if zip_file_path:
             if destination_path:
-                if not os.path.isdir(destination_path):
-                    os.makedirs(destination_path)
                 final_file_path = self._preppend_time_to_destination_filename(
                     destination_path, zip_file_path
                 )

--- a/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_content_validations.py
@@ -193,7 +193,7 @@ class ArticleContentValidation(object):
                     self.article_date_types,
                     self.toc_section,
                     self.doi,
-                    self.doi_and_lang,
+                    self.doi_by_lang,
                     self.article_id,
                     self.pagination,
                 ])
@@ -617,16 +617,16 @@ class ArticleContentValidation(object):
         return r
 
     @property
-    def doi_and_lang(self):
+    def doi_by_lang(self):
         r = []
         if not self.article.doi:
             return r
-        doi_items = [doi for lang, doi in self.article.doi_and_lang
+        doi_items = [doi for lang, doi in self.article.doi_by_lang
                      if doi != '']
         unique = set(doi_items)
         if len(unique) < len(doi_items):
             msg = '; '.join(['{}:&#160;{}'.format(lang, doi)
-                            for lang, doi in self.article.doi_and_lang])
+                            for lang, doi in self.article.doi_by_lang])
             r.append(
                 ('doi',
                  validation_status.STATUS_FATAL_ERROR,

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -679,7 +679,12 @@ def display_article_metadata(_article, sep='<br/>'):
         "{}: {}".format(lang, doi or '-')
         for lang, doi in _article.doi_by_lang
     ))
+    article_types = " | ".join((
+        "{}: {}".format(lang, article_type or '-')
+        for lang, article_type in _article.article_types
+    ))
     r = "".join((
+        html_reports.tag('p', article_types),
         html_reports.tag(
             'p', _article.scielo_id, 'pid'),
         html_reports.tag(

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -677,11 +677,12 @@ def validations_table(results):
 def display_article_metadata(_article, sep='<br/>'):
     r = "".join((
         html_reports.tag(
+            'p', _article.scielo_id, 'pid'),
+        html_reports.tag(
             'p', _article.doi or _article.publisher_article_id, 'doi'),
         html_reports.tag(
             'p',
-            html_reports.tag(
-                'strong', "PID (AOP): {}".format(str(_article.previous_pid)))),
+            "PID (AOP): {}".format(str(_article.previous_pid)), 'aop'),
         html_reports.tag(
             'p', html_reports.tag('strong', _article.pages), 'fpage'),
         display_article_dates(_article, 'p'),

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -675,18 +675,25 @@ def validations_table(results):
 
 
 def display_article_metadata(_article, sep='<br/>'):
+    r = "".join((
+        html_reports.tag(
+            'p', _article.doi or _article.publisher_article_id, 'doi'),
+        html_reports.tag(
+            'p',
+            html_reports.tag(
+                'strong', "PID (AOP): {}".format(str(_article.previous_pid)))),
+        html_reports.tag(
+            'p', html_reports.tag('strong', _article.pages), 'fpage'),
+        display_article_dates(_article, 'p'),
+        html_reports.tag(
+            'p', html_reports.tag('strong', _article.title), 'article-title'),
+        html_reports.tag(
+            'p', display_authors(_article.article_contrib_items, sep)),
+    ))
 
-    r = ''
-    r += html_reports.tag('p', _article.doi or _article.publisher_article_id, 'doi')
-    r += html_reports.tag(
-        'p',
-        html_reports.tag('strong', "PID (AOP): {}".format(str(_article.previous_pid))))
-    r += html_reports.tag('p', html_reports.tag('strong', _article.pages), 'fpage')
-    r += display_article_dates(_article, 'p')
-    r += html_reports.tag('p', html_reports.tag('strong', _article.title), 'article-title')
-    r += html_reports.tag('p', display_authors(_article.article_contrib_items, sep))
     if _article.marked_to_delete:
-        r = html_reports.tag('p', _('MARKED TO DELETE'), 'warning') + html_reports.tag('div', r, 'delete')
+        r = (html_reports.tag('p', _('MARKED TO DELETE'), 'warning') +
+             html_reports.tag('div', r, 'delete'))
     return r
 
 

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -677,18 +677,10 @@ def validations_table(results):
 def display_article_metadata(_article, sep='<br/>'):
 
     r = ''
-    if _article.doi is not None:
-        r += html_reports.tag('p', _article.doi, 'doi')
-    else:
-        r += html_reports.tag('p', _article.publisher_article_id, 'doi')
-    if _article.previous_pid:
-        r += html_reports.tag(
-            'p',
-            html_reports.tag('strong', "PID (AOP): " + _article.previous_pid))
-    else:
-        r += html_reports.tag(
-            'p', html_reports.tag('strong', "PID (AOP): none"))
-
+    r += html_reports.tag('p', _article.doi or _article.publisher_article_id, 'doi')
+    r += html_reports.tag(
+        'p',
+        html_reports.tag('strong', "PID (AOP): {}".format(str(_article.previous_pid))))
     r += html_reports.tag('p', html_reports.tag('strong', _article.pages), 'fpage')
     r += display_article_dates(_article, 'p')
     r += html_reports.tag('p', html_reports.tag('strong', _article.title), 'article-title')

--- a/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
+++ b/src/scielo/bin/xml/prodtools/validations/article_data_reports.py
@@ -675,11 +675,16 @@ def validations_table(results):
 
 
 def display_article_metadata(_article, sep='<br/>'):
+    doi_by_lang_items = " | ".join((
+        "{}: {}".format(lang, doi or '-')
+        for lang, doi in _article.doi_by_lang
+    ))
     r = "".join((
         html_reports.tag(
             'p', _article.scielo_id, 'pid'),
         html_reports.tag(
             'p', _article.doi or _article.publisher_article_id, 'doi'),
+        html_reports.tag('p', doi_by_lang_items, 'doi'),
         html_reports.tag(
             'p',
             "PID (AOP): {}".format(str(_article.previous_pid)), 'aop'),

--- a/src/scielo/bin/xml/prodtools/validations/doi_validations.py
+++ b/src/scielo/bin/xml/prodtools/validations/doi_validations.py
@@ -25,7 +25,7 @@ class DOIValidator(object):
         year = (
             article.real_pubdate or article.expected_pubdate or {}).get('year')
         journal_prefixes = self.journal_prefixes(journal_issns, year)
-        for lang, doi in article.doi_and_lang:
+        for lang, doi in article.doi_by_lang:
             if not doi:
                 continue
             self.validate_issn_in_doi(journal_issns, doi)


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta dados do pacote no relatório para melhor rastreabilidade na integração com SPF, tais como:
- pid v3
- nome do pacote que foi depositado para o SPF
- idioma vs doi
- idioma vs `@article-type`

#### Onde a revisão poderia começar?
por commits, a partir de [f4de8de](https://github.com/scieloorg/PC-Programs/commit/f4de8def6d76367329c24888aeb0e7d701d25366)

#### Como este poderia ser testado manualmente?
Executando o XC:

`python xml_converter.py <pasta_do_pacote>`

para visualizar:
- pid v3
- nome do pacote que foi depositado para o SPF

desde que estejam configurados, respectivamente pid_manager e kernel gate. 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="1072" alt="Captura de Tela 2020-07-11 às 13 37 09" src="https://user-images.githubusercontent.com/505143/87296928-f5455680-c4dd-11ea-8561-5a7e0f6c0807.png">

#### Quais são tickets relevantes?
closes #3316

### Referências
- [configuração do XC](https://github.com/scieloorg/PC-Programs/blob/master/docs/source/xc.md)
