### PR TITLE
Faz tratamento de exceção quando pacote não contém XML

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/package.py
+++ b/src/scielo/bin/xml/prodtools/data/package.py
@@ -9,6 +9,10 @@ from prodtools.data import workarea
 logger = logging.getLogger()
 
 
+class PackageHasNoXMLFilesError(Exception):
+    pass
+
+
 class SPPackage(object):
     """
     Contém dados (files + xml + article) de um conjunto de documentos

--- a/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
+++ b/src/scielo/bin/xml/prodtools/processing/sps_pkgmaker.py
@@ -21,10 +21,6 @@ mime = MimeTypes()
 logger = logging.getLogger()
 
 
-class PackageHasNoXMLFilesError(Exception):
-    pass
-
-
 class PackageMakerOptimiserPreReqError(Exception):
     pass
 
@@ -414,7 +410,7 @@ class PackageMaker(object):
                     ", ".join(xml_list)
                 )
             logger.exception(error_msg)
-            raise PackageHasNoXMLFilesError(error_msg)
+            raise package.PackageHasNoXMLFilesError(error_msg)
 
         optimise_individually = (percent < 1)
 

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -25,7 +25,7 @@ class Mailer(object):
         self.mailer.send_message(to, subject, text, attaches)
 
     def mail_invalid_packages(self, invalid_pkg_files):
-        if self.config.is_enabled_email_service:
+        if invalid_pkg_files:
             self.send_message(self.config.email_to, self.config.email_subject_invalid_packages, self.config.email_text_invalid_packages + '\n'.join(invalid_pkg_files))
 
     def mail_failure(self, subject: str, text: str, package: str) -> None:

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -25,12 +25,12 @@ class Mailer(object):
         self.mailer.send_message(to, subject, text, attaches)
 
     def mail_invalid_packages(self, invalid_pkg_files):
-        if invalid_pkg_files:
+        for invalid_pkg in invalid_pkg_files:
             self.send_message(
                 self.config.email_to,
-                self.config.email_subject_invalid_packages,
+                self.config.email_subject_invalid_packages + " " + invalid_pkg,
                 self.config.email_text_invalid_packages +
-                '\n'.join(invalid_pkg_files))
+                invalid_pkg)
 
     def mail_failure(self, subject: str, text: str, package: str) -> None:
         """Informa falhas gerais ocorridas durante a conversão de pacotes SPS"""

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -26,7 +26,11 @@ class Mailer(object):
 
     def mail_invalid_packages(self, invalid_pkg_files):
         if invalid_pkg_files:
-            self.send_message(self.config.email_to, self.config.email_subject_invalid_packages, self.config.email_text_invalid_packages + '\n'.join(invalid_pkg_files))
+            self.send_message(
+                self.config.email_to,
+                self.config.email_subject_invalid_packages,
+                self.config.email_text_invalid_packages +
+                '\n'.join(invalid_pkg_files))
 
     def mail_failure(self, subject: str, text: str, package: str) -> None:
         """Informa falhas gerais ocorridas durante a conversão de pacotes SPS"""

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -25,10 +25,14 @@ class Mailer(object):
         self.mailer.send_message(to, subject, text, attaches)
 
     def mail_invalid_packages(self, invalid_pkg_files):
+        icon = u"\u274C"
+        subject = "{}: {} ".format(
+            self.config.email_subject_invalid_packages, icon)
+
         for invalid_pkg in invalid_pkg_files:
             self.send_message(
                 self.config.email_to,
-                self.config.email_subject_invalid_packages + " " + invalid_pkg,
+                subject + invalid_pkg,
                 self.config.email_text_invalid_packages +
                 invalid_pkg)
 

--- a/src/scielo/bin/xml/prodtools/server/mailer.py
+++ b/src/scielo/bin/xml/prodtools/server/mailer.py
@@ -28,13 +28,17 @@ class Mailer(object):
         icon = u"\u274C"
         subject = "{}: {} ".format(
             self.config.email_subject_invalid_packages, icon)
+        body = "{}{}\n\nPackages are not .zip file or has no XML file"
 
         for invalid_pkg in invalid_pkg_files:
             self.send_message(
                 self.config.email_to,
                 subject + invalid_pkg,
-                self.config.email_text_invalid_packages +
-                invalid_pkg)
+                body.format(
+                    self.config.email_text_invalid_packages,
+                    invalid_pkg
+                )
+            )
 
     def mail_failure(self, subject: str, text: str, package: str) -> None:
         """Informa falhas gerais ocorridas durante a conversão de pacotes SPS"""

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -304,9 +304,19 @@ class Reception(object):
             if not os.path.isdir(queued_pkg_path):
                 os.makedirs(queued_pkg_path)
 
-            if fs_utils.extract_package(tmp_pkg_path, queued_pkg_path):
-                if archive_path and os.path.isdir(archive_path):
-                    shutil.copy(tmp_pkg_path, archive_path)
+            if archive_path:
+                if not os.path.isdir(archive_path):
+                    os.makedirs(archive_path)
+                shutil.copy(tmp_pkg_path, archive_path)
+
+            extracted = fs_utils.extract_package(tmp_pkg_path, queued_pkg_path)
+            if extracted:
+                xml_items = [item
+                             for item in os.listdir(queued_pkg_path)
+                             if item.endswith(".xml")]
+                extracted = len(xml_items)
+
+            if extracted:
                 pkg_paths.append(queued_pkg_path)
             else:
                 invalid_pkg_files.append(pkg_name)

--- a/src/scielo/bin/xml/prodtools/xc.py
+++ b/src/scielo/bin/xml/prodtools/xc.py
@@ -9,7 +9,6 @@ import traceback
 from tempfile import TemporaryDirectory
 from datetime import datetime
 
-from prodtools import _
 from packtools.utils import SPPackage
 
 try:
@@ -17,7 +16,8 @@ try:
 except ImportError as e:
     print(e)
     print("It is ok if running on a server without GUI")
-
+from prodtools import _
+from prodtools.data.package import PackageHasNoXMLFilesError
 from prodtools.utils import fs_utils
 from prodtools.utils import encoding
 from prodtools.processing import pkg_processors
@@ -166,6 +166,12 @@ class Reception(object):
             try:
                 package = self._create_package_instance(source=xml_path, output=output_path)
                 scilista_items, xc_status, mail_info = self.proc.convert_package(package)
+            except PackageHasNoXMLFilesError:
+                logger.exception(
+                    "Invalid package '%s'. There is no XML file",
+                    package_path,
+                )
+                self.mailer.mail_invalid_packages([package_path])
             except Exception:
                 logger.exception(
                     "Could not convert the package '%s'. The following traceback was captured: ",

--- a/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
+++ b/src/scielo/bin/xml/tests/test_sps_pkgmaker.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from prodtools.utils import xml_utils
 from prodtools.processing import sps_pkgmaker
+from prodtools.data.package import PackageHasNoXMLFilesError
 
 
 python_version = sys.version_info.major
@@ -331,7 +332,7 @@ class TestPackageMaker(TestCase):
         mock_listdir.return_value = ["a.pdf", "a.jpg"]
         pm = sps_pkgmaker.PackageMaker(
             "/path", "/tmp", optimise=False, package_name=None)
-        with self.assertRaises(sps_pkgmaker.PackageHasNoXMLFilesError):
+        with self.assertRaises(PackageHasNoXMLFilesError):
             pm.pack()
 
     @patch("prodtools.processing.sps_pkgmaker.package.SPPackage")


### PR DESCRIPTION
#### O que esse PR faz?
Faz tratamento de exceção quando pacote não contém XML

#### Onde a revisão poderia começar?
Por commits, a partir de [5813b15](https://github.com/scieloorg/PC-Programs/commit/5813b15e65c3b692f57e722e5dd48d7c2bd7d7a9)

#### Como este poderia ser testado manualmente?
Executando o XC server com um pacote qq que não contenha XML.

#### Algum cenário de contexto que queira dar?
O problema ocorre somente no server pois no Windows, a interface de usuário obriga o usuário a informar um caminho com XML, tanto no terminal quanto no formulário.

### Screenshots

Lista de emails

<img width="1122" alt="Captura de Tela 2020-07-13 às 18 00 16" src="https://user-images.githubusercontent.com/505143/87355103-26ea0c00-c536-11ea-8fa0-e97957adf53a.png">

Conteúdo do email

<img width="994" alt="Captura de Tela 2020-07-13 às 18 00 25" src="https://user-images.githubusercontent.com/505143/87355095-22bdee80-c536-11ea-81c5-c21ccdff7e1d.png">

#### Quais são tickets relevantes?
closes #3260 

### Referências
n/a
