### PR TITLE
Corrige o xpath para filtrar e manter no XML apenas os xref de determinado tipo

### DIFF
--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -577,14 +577,14 @@ class ArticleXML(object):
             if xref_type not in _any_xref_ranges.keys():
                 _any_xref_ranges[xref_type] = []
             for xref_parent_node, xref_node_items in xref_type_nodes:
-                
+
                 # remove todas as tags exceto xref para conseguir identificar
                 # o texto entre as tags xref, se há o padrão de "intervalo",
                 # ou seja, hífen entre tags xref
                 parent_node_copy = deepcopy(xref_parent_node)
                 strip_all_tags_except(
                     parent_node_copy,
-                    ["xref[@ref-type='{}']".format(xref_type)])
+                    [".//xref[@ref-type='{}']".format(xref_type)])
 
                 pattern = "xref[@ref-type='{}']".format(xref_type)
                 for i, xref in enumerate(parent_node_copy.xpath(pattern)):

--- a/src/scielo/bin/xml/prodtools/data/article.py
+++ b/src/scielo/bin/xml/prodtools/data/article.py
@@ -582,7 +582,9 @@ class ArticleXML(object):
                 # o texto entre as tags xref, se há o padrão de "intervalo",
                 # ou seja, hífen entre tags xref
                 parent_node_copy = deepcopy(xref_parent_node)
-                strip_all_tags_except(parent_node_copy, ["xref"])
+                strip_all_tags_except(
+                    parent_node_copy,
+                    ["xref[@ref-type='{}']".format(xref_type)])
 
                 pattern = "xref[@ref-type='{}']".format(xref_type)
                 for i, xref in enumerate(parent_node_copy.xpath(pattern)):

--- a/src/scielo/bin/xml/prodtools/utils/xml_utils.py
+++ b/src/scielo/bin/xml/prodtools/utils/xml_utils.py
@@ -593,12 +593,17 @@ def nodes_tostring(root, node_xpaths):
     return [tostring(node) for node in find_nodes(root, node_xpaths)]
 
 
-def strip_all_tags_except(root, keep_tags):
+def strip_all_tags_except(root, keep_xpaths):
+    for xpath in keep_xpaths:
+        for node in root.findall(xpath):
+            node.set("KEEP", "true")
     for node in root.findall(".//*"):
-        if node.tag in keep_tags:
+        if node.get("KEEP"):
             continue
         node.tag = "REMOVE"
     etree.strip_tags(root, "REMOVE")
+    for node in root.findall(".//*"):
+        node.attrib.pop("KEEP")
 
 
 def node_text(node):

--- a/src/scielo/bin/xml/tests/test_xml_utils.py
+++ b/src/scielo/bin/xml/tests/test_xml_utils.py
@@ -640,3 +640,44 @@ class TestNodeText(TestCase):
         xml = xml_utils.etree.fromstring(text)
         result = xml_utils.node_text(xml.find(".//p"))
         self.assertEqual(expected, result)
+
+
+class TestStripAllTagsExcept(TestCase):
+
+    def test_strip_all_tags_except_removes_all_a_except_a_with_href(self):
+        text = """<root><p>
+            <a>Texto 1</a>
+            <a href="x">Ciência</a>
+            <a href="y">Arte</a>
+            <a>Texto 2</a>
+            </p></root>"""
+        expected = """<p>
+            Texto 1
+            <a href="x">Ciência</a>
+            <a href="y">Arte</a>
+            Texto 2
+            </p>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        xml_utils.strip_all_tags_except(node, [".//a[@href]"])
+        result = xml_utils.tostring(node)
+        self.assertEqual(expected, result)
+
+    def test_strip_all_tags_except_removes_all_a_except_a_with_href_equal_to_x(self):
+        text = """<root><p>
+            <a>Texto 1</a>
+            <a href="x">Ciência</a>
+            <a href="y">Arte</a>
+            <a>Texto 2</a>
+            </p></root>"""
+        expected = """<p>
+            Texto 1
+            <a href="x">Ciência</a>
+            Arte
+            Texto 2
+            </p>"""
+        xml = xml_utils.etree.fromstring(text)
+        node = xml.find(".//p")
+        xml_utils.strip_all_tags_except(node, [".//a[@href='x']"])
+        result = xml_utils.tostring(node)
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige um bug inserido no PR #3315. Faltava inserir no xpath o filtro do `@ref-type` específico.
Evitando assim a exceção mencionada no issue #3320


#### Onde a revisão poderia começar?
por commits, a partir do [82ad423](https://github.com/scieloorg/PC-Programs/commit/82ad423a1af6eecfe437ee482305c20f70a7f1ea) 

#### Como este poderia ser testado manualmente?
Execute o xpm ou xc usando o pacote mencionado no #3320 

`python xml_package_maker.py <pasta do pacote>`

#### Algum cenário de contexto que queira dar?
O erro acontecia porque a quantidade de //xref encontrada no XML resultante era mais do que o esperado, pois dentre eles havia um `xref[@ref-type='fn']`, causando o IndexError.

### Screenshots
n/a

#### Quais são tickets relevantes?
closes #3320 

### Referências
n/a
