### PR TITLE
Corrige as chamadas a python dentro do instalador (.wse), colocando aspas nos parâmetros

### DIFF
--- a/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
+++ b/src/install/wise/scielo-pc-programs-4.0.097-prodtools.wse
@@ -34,7 +34,7 @@ item: Global
   Version Company=SciELO
   Distribute Path=C:\2007\scielo
   Distribute Type=1
-  Step View=All
+  Step View=Properties
   Variable Name1=_SYS_
   Variable Default1=C:\WINNT\system32
   Variable Flags1=00001000
@@ -255,9 +255,9 @@ item: Install File
   Flags=0000000010000010
 end
 item: Execute Program
-  Pathname=%PYTHON_PATH%\python
-  Command Line= %PROGDIR%\bin\cfg\configure_paths.py %PYTHON_PATH% %PROGDIR%
-  Flags=00000110
+  Pathname="%PYTHON_PATH%\python"
+  Command Line= %PROGDIR%\bin\cfg\configure_paths.py "%PYTHON_PATH%" "%PROGDIR%"
+  Flags=00000011
 end
 item: Read INI Value
   Variable=WEBPATH
@@ -1897,9 +1897,9 @@ item: Install File
   Flags=0000000010000010
 end
 item: Execute Program
-  Pathname=%PYTHON_PATH%\Scripts\pip
-  Command Line=install -U %PROGDIR%\bin\xml\dist\SciELO_Production_Tools-4.0.97-py3-none-any.whl
-  Flags=00000110
+  Pathname="%PYTHON_PATH%\Scripts\pip"
+  Command Line=install -U "%PROGDIR%\bin\xml\dist\SciELO_Production_Tools-4.0.97-py3-none-any.whl"
+  Flags=00000011
 end
 item: Install File
   Source=e:\github.com\scieloorg\PC-Programs\src\scielo\bin\xml\__init__.py
@@ -2113,6 +2113,11 @@ end
 item: Install File
   Source=e:\github.com\scieloorg\PC-Programs\src\scielo\bin\cfg\Settings.cfg.template
   Destination=%PROGDIR%\bin\cfg\Settings.cfg.template
+  Flags=0000000010000010
+end
+item: Install File
+  Source=e:\github.com\scieloorg\PC-Programs\src\scielo\bin\cfg\Scielo.ico
+  Destination=%PROGDIR%\bin\xml\prodtools\settings\Scielo.ico
   Flags=0000000010000010
 end
 item: Install File
@@ -5510,9 +5515,9 @@ item: Create Shortcut
   Destination=%DESKTOPDIR%\XML Converter.lnk
   Destination Portuguese=%DESKTOPDIR%\XML Converter.lnk
   Destination Spanish=%DESKTOPDIR%\XML Converter.lnk
-  Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
-  Command Options Spanish=%PROGDIR%
+  Command Options=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Portuguese=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Spanish=%PROGDIR% "%PYTHON_PATH%\python"
   Icon Number=0
   Icon Number Portuguese=0
   Icon Number Spanish=0
@@ -5529,9 +5534,9 @@ item: Create Shortcut
   Destination=%DESKTOPDIR%\XML Package Maker.lnk
   Destination Portuguese=%DESKTOPDIR%\XML Package Maker.lnk
   Destination Spanish=%DESKTOPDIR%\XML Package Maker.lnk
-  Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
-  Command Options Spanish=%PROGDIR%
+  Command Options=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Portuguese=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Spanish=%PROGDIR% "%PYTHON_PATH%\python"
   Icon Number=0
   Icon Number Portuguese=0
   Icon Number Spanish=0
@@ -5548,9 +5553,9 @@ item: Create Shortcut
   Destination=%DESKTOPDIR%\Markup - update journals list.lnk
   Destination Portuguese=%DESKTOPDIR%\Markup - update journals list.lnk
   Destination Spanish=%DESKTOPDIR%\Markup - update journals list.lnk
-  Command Options=%PROGDIR%
-  Command Options Portuguese=%PROGDIR% %PYTHON_PATH%\python
-  Command Options Spanish=%PROGDIR%
+  Command Options=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Portuguese=%PROGDIR% "%PYTHON_PATH%\python"
+  Command Options Spanish=%PROGDIR% "%PYTHON_PATH%\python"
   Icon Number=0
   Icon Number Portuguese=0
   Icon Number Spanish=0
@@ -5675,8 +5680,8 @@ item: End Block
 end
 item: Execute Program
   Pathname=%PYTHON_PATH%\python
-  Command Line= %PROGDIR%\bin\cfg\configure_paths.py %PYTHON_PATH% %PROGDIR% %DATADIR% %MYSCIELOURL% %WEBPATH%
-  Flags=00000110
+  Command Line= %PROGDIR%\bin\cfg\configure_paths.py "%PYTHON_PATH%" "%PROGDIR%" "%DATADIR%" "%MYSCIELOURL%" "%WEBPATH%"
+  Flags=00000011
 end
 remarked item: Execute Program
   Pathname=python

--- a/src/scielo/bin/xml/xml_converter.bat
+++ b/src/scielo/bin/xml/xml_converter.bat
@@ -2,4 +2,4 @@ set apppath=%1
 set python_call=%2
 
 cd %apppath%\bin\xml
-%python_call% xm_converter.py
+%python_call% xml_converter.py

--- a/src/scielo/bin/xml/xml_package_maker.bat
+++ b/src/scielo/bin/xml/xml_package_maker.bat
@@ -2,4 +2,4 @@ set apppath=%1
 set python_call=%2
 
 cd %apppath%\bin\xml
-%python_call% xm_package_maker.py
+%python_call% xml_package_maker.py


### PR DESCRIPTION
#### O que esse PR faz?
Corrige as chamadas a python dentro do instalador (.wse), colocando aspas nos parâmetros
Corrige a chamada nos atalhos

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o instalador

#### Algum cenário de contexto que queira dar?
Atalhos:

`C:\novo-scielo\bin\xml\xml_package_maker.bat C:\novo-scielo "C:\Program Files (x86)\Python38-32\python"`
`C:\novo-scielo\bin\xml\download_markup_journals.bat C:\novo-scielo "C:\Program Files (x86)\Python38-32\python"`
`C:\novo-scielo\bin\xml\xml_converter.bat C:\novo-scielo "C:\Program Files (x86)\Python38-32\python"`

### Screenshots


<img width="670" alt="Captura de Tela 2020-07-20 às 19 23 56" src="https://user-images.githubusercontent.com/505143/88092326-b448e400-cb66-11ea-8875-36cfadb5ee75.png">
<img width="665" alt="Captura de Tela 2020-07-20 às 19 24 17" src="https://user-images.githubusercontent.com/505143/88092334-b7dc6b00-cb66-11ea-9674-766cc5cf7dbe.png">
<img width="665" alt="Captura de Tela 2020-07-20 às 19 24 32" src="https://user-images.githubusercontent.com/505143/88092336-b90d9800-cb66-11ea-980e-89b0326334a5.png">
<img width="383" alt="Captura de Tela 2020-07-20 às 19 30 49" src="https://user-images.githubusercontent.com/505143/88092340-ba3ec500-cb66-11ea-9aad-bc82b413f01c.png">

<img width="483" alt="Captura de Tela 2020-07-20 às 19 30 59" src="https://user-images.githubusercontent.com/505143/88092343-ba3ec500-cb66-11ea-835e-a7a2000614b3.png">
<img width="487" alt="Captura de Tela 2020-07-20 às 19 31 28" src="https://user-images.githubusercontent.com/505143/88092345-bad75b80-cb66-11ea-9022-3be025df23b2.png">
<img width="484" alt="Captura de Tela 2020-07-20 às 19 32 39" src="https://user-images.githubusercontent.com/505143/88092346-bb6ff200-cb66-11ea-883f-c5aa432f5d74.png">

#### Quais são tickets relevantes?
#3255 

### Referências
n/a
