### PR TITLE
Corrige a geração do script `temp\xml_pubmed.bat`

### DIFF
--- a/src/scielo/xml_scielo/proc/general/scripts/generateXML.bat
+++ b/src/scielo/xml_scielo/proc/general/scripts/generateXML.bat
@@ -25,7 +25,7 @@ if exist %mydbahead1%.mst call batch\GeraInvertido.bat %mydbahead1% %FST% %mydba
 if not exist %mydb%.mst goto END_GENERATE_XML
 call batch\GeraInvertido.bat %mydbinv% %FST% %mydbinv%
 
-echo > temp\xml_scielo_xsl.seq
+echo. > temp\xml_scielo_xsl.seq
 
 echo Getting XSL list >> %LOG%
 %WXIS% IsisScript=xis\xml_scielo_getXSL.xis acron=%acron% issueid=%issueid% generate_linkout=%generate_linkout% ahpdate=%ahpdate% cipar=%CIPAR_FILE% xslList=temp\xml_scielo_xsl.seq debug=%debug% destination=%EXPORT_TO% maxdate=%maxdate% >> %LOG%

--- a/src/scielo/xml_scielo/proc/general/scripts/mainGenerateXML.bat
+++ b/src/scielo/xml_scielo/proc/general/scripts/mainGenerateXML.bat
@@ -109,7 +109,8 @@ call temp\generateXML4scilista.bat
 
 if not "%1"=="PUBMED" goto END
 if not exist ..\..\..\bin\xml\xml_pubmed.py goto END
-%MX% "seq=%SCI_LISTA% " lw=9999 "pft=if p(v1) then 'cd ..\..\..\bin\xml'/,'python xml_pubmed.py %Serial_Directory%\',v1,'\',v2,' ',v4,' ',v5/ fi" now> temp\xml_pubmed.bat
+%MX% null count=1 "pft='cd ..\..\..\bin\xml'/" now> temp\xml_pubmed.bat
+%MX% "seq=%SCI_LISTA% " lw=9999 "pft=if p(v1) then 'python xml_pubmed.py %Serial_Directory%\',v1,'\',v2,' ',v4,' ',v5/ fi" now>> temp\xml_pubmed.bat
 call temp\xml_pubmed.bat
 goto END
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a geração do script `temp\xml_pubmed.bat` removendo as linhas excedentes do comando `cd ..\..\..\bin\xml` e mantendo apenas a primeira.

A execução correta deste módulo sobrescreve o XML do PubMed da versão DTD 2.4 com uma versão mais atualizada 2.8 que gerar mais de uma afiliação e `orcid`

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executando o comando GenerateXML_PubMed.bat no servidor Windows usado pela produção

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3324 

### Referências
n/a
